### PR TITLE
Add MoE concept and Agent-as-a-Judge paper analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,13 @@
 # cleveres-ai
 A smart knowledge base about artificial intelligence.
 
-## Prompt Engineering Techniques
+## Frontier Research & Papers
+*   [Agent-as-a-Judge: Evaluate Agents with Agents](papers/agent-as-a-judge.md) - *Evaluating autonomous agents by using other agents to verify their process.*
 
+## Core Concepts & Architecture
+*   [Mixture of Experts (MoE): Scaling Parameters Without Scaling Costs](concepts/mixture-of-experts.md) - *How models like Mixtral and DeepSeek scale efficiently.*
+
+## Prompt Engineering Techniques
 *   [Double Question Prompting: Overcoming Causal LLM Limitations](techniques/double-question-prompting.md)
 
 ## Telegram

--- a/concepts/mixture-of-experts.md
+++ b/concepts/mixture-of-experts.md
@@ -1,0 +1,58 @@
+# Mixture of Experts (MoE): Scaling Intelligence Efficiently
+
+**Category:** Foundational / Architecture
+**Key Concepts:** Sparse Activation, Gating Networks, conditional computation
+
+## TL;DR
+Mixture of Experts (MoE) is a model architecture that replaces dense Feed-Forward Networks (FFNs) with multiple specialized "expert" networks. For each token generated, a "gating network" (router) selects only a small subset of these experts to process the data. This allows models to have massive total parameter counts (e.g., trillions) while only using a tiny fraction (e.g., billions) for inference, dramatically reducing computational cost and latency.
+
+---
+
+## The Core Problem: The Dense Scaling Wall
+In traditional "dense" Large Language Models (like Llama 2 or GPT-3), every single parameter in the neural network is used for every single token processed.
+*   **Pro:** Simple to train and architect.
+*   **Con:** Computational cost scales linearly with model size. A 1T parameter dense model is roughly 10x slower and more expensive to run than a 100B parameter model.
+
+This creates a bottleneck: to make models smarter, we need more parameters, but more parameters make them too slow and expensive to run.
+
+## How MoE Solves It: Sparse Activation
+MoE introduces **Sparse Activation**. Instead of one giant neural network that knows everything, the model is divided into many smaller "experts".
+
+### Key Components
+1.  **Experts:** These are independent Feed-Forward Networks (FFN). In a MoE layer, you might have 8, 64, or even hundreds of experts.
+2.  **The Gating Network (Router):** A small neural network that sits before the experts. It looks at the incoming token (e.g., the word "python") and decides which expert is best suited to handle it.
+    *   *Example:* If the input is code, the router might send it to "Expert 4" (specialized in syntax). If the input is a poem, it might send it to "Expert 7" (specialized in rhyme).
+
+### The Math of Efficiency
+In a typical setup like **Mixtral 8x7B**:
+*   **Total Parameters:** ~47 Billion (all experts combined).
+*   **Active Parameters:** ~13 Billion (only 2 experts are used per token).
+*   **Result:** You get the knowledge capacity of a 47B model but the inference speed of a 13B model.
+
+## Challenges & Trade-offs
+*   **VRAM Usage:** While *compute* is low, *memory* usage is high. You still need to load all 47B parameters into GPU memory (VRAM), even if you don't use them all at once. This makes MoE hard to run on consumer hardware.
+*   **Training Instability:** Training a router to be fair is hard. If the router only picks "Expert 1" for everything, the other experts never learn (this is called "expert collapse").
+*   **Fine-tuning Difficulty:** Fine-tuning MoEs can be trickier than dense models due to overfitting on specific experts.
+
+---
+
+## Real-World Application & Who Should Care
+
+### 🚀 The Performance Monsters (SOTA Seekers)
+**Why you care:** MoE models (like **DeepSeek-V3**, **Mixtral 8x22B**, **Grok-1**) currently offer some of the best reasoning-per-dollar ratios. They often outperform dense models of similar active parameter counts.
+**Action:** When evaluating models for complex reasoning tasks, prioritize MoE architectures if you are constrained by inference latency but have sufficient VRAM. For example, frameworks like [Agent-as-a-Judge](../papers/agent-as-a-judge.md) require running many evaluations, making MoE's efficiency critical.
+
+### 💰 The Cost & Latency Optimizers (API Developers)
+**Why you care:** MoE is the secret sauce behind the plummeting cost of intelligence. Providers like DeepSeek and Mistral can offer GPT-4 class performance at 1/10th the price because their backend compute costs are significantly lower due to sparsity.
+**Action:** Adopt MoE-based endpoints (e.g., `deepseek-chat`, `mistral-small`) for high-volume background tasks. You get "big model" smarts with "small model" latency and pricing.
+
+### 🧑‍💻 The Everyday Prompt Engineers
+**Why you care:** You might notice that MoE models sometimes feel "spiky" in their knowledge—brilliant at one topic, slightly inconsistent at another. This is a side effect of specialization.
+**Action:** If an MoE model (like Mixtral) gives a weird answer, try slightly rephrasing the prompt to trigger a different set of experts. The "routing" is dynamic, so a small change in input can activate a smarter path in the model.
+
+---
+
+## References
+*   [Outrageously Large Neural Networks: The Sparsely-Gated Mixture-of-Experts Layer (Shazeer et al., 2017)](https://arxiv.org/abs/1701.06538) - The modern foundation.
+*   [Mixtral of Experts (Mistral AI, 2024)](https://arxiv.org/abs/2401.04088) - Popularized open-weights MoE.
+*   [DeepSeekMoE: Towards Ultimate Expert Specialization (DeepSeek, 2024)](https://arxiv.org/abs/2401.06066) - Advanced fine-grained expert segmentation.

--- a/papers/agent-as-a-judge.md
+++ b/papers/agent-as-a-judge.md
@@ -1,0 +1,55 @@
+# Agent-as-a-Judge: Evaluate Agents with Agents
+
+**Category:** Frontier / Research Paper
+**Paper:** [Agent-as-a-Judge: Evaluate Agents with Agents (Zhuge et al., 2024)](https://arxiv.org/abs/2410.10934)
+**Date:** October 2024 (Trending)
+
+## TL;DR
+As AI systems evolve from simple chatbots to autonomous agents that use tools and execute code, traditional evaluation methods (like human review or static "LLM-as-a-Judge") are breaking down. "Agent-as-a-Judge" is a new framework where an advanced AI agent acts as the evaluator, capable of verifying not just the final text output, but the *entire process*: code execution, tool usage, and intermediate reasoning steps.
+
+---
+
+## The Shift: From Text to Action
+The industry standard for evaluating LLMs has been **"LLM-as-a-Judge"** (e.g., using GPT-4 to grade the quality of a summary written by Llama 3). This works well for static text tasks.
+
+However, modern AI agents perform **multi-step actions**:
+1.  Write a Python script.
+2.  Execute the script to scrape a website.
+3.  Process the data.
+4.  Generate a report.
+
+A static judge only sees the final report. It has no idea if the script was efficient, if the data was scraped correctly, or if the agent hallucinated the intermediate steps.
+
+## How "Agent-as-a-Judge" Works
+The paper proposes an evaluator that is itself an agent. It doesn't just read; it *investigates*.
+
+1.  **Process Supervision:** The judge watches the agent's "Chain-of-Thought" and tool calls in real-time.
+2.  **Tool-Augmented Verification:** The judge can run its own verification code.
+    *   *Example:* If the target agent claims "I solved the math problem by writing code," the Judge Agent can take that code, run it in a sandbox, and verify the output matches the claim.
+3.  **Multi-Turn Feedback:** The judge provides granular feedback on *where* the agent failed (e.g., "Your Python syntax was correct, but the API endpoint you called is deprecated"), enabling better self-correction.
+
+## The DevAI Benchmark
+To prove this concept, the authors introduced **DevAI**, a benchmark of 55 realistic, complex tasks (like automated software development) specifically designed to test this new evaluation paradigm. They found that Agent-as-a-Judge provides much higher correlation with human judgment than standard methods.
+
+---
+
+## Real-World Application & Who Should Care
+
+### 🚀 The Performance Monsters (SOTA Seekers)
+**Why you care:** If you are building autonomous agents (e.g., for coding or data analysis), you cannot rely on simple BLEU/ROUGE scores or even standard GPT-4 grading.
+**Action:** Implement an "Agent-as-a-Judge" loop in your training or evaluation pipeline. Have a strong model (like Claude 3.5 Sonnet or GPT-4o) act as a supervisor that executes the code your smaller agents produce to verify correctness before acceptance.
+
+### 💰 The Cost & Latency Optimizers (API Developers)
+**Why you care:** Agent-as-a-Judge is **expensive**. It requires multiple inference calls and potentially sandboxed code execution for every single evaluation.
+**Action:** Do NOT use this for real-time monitoring of every user request. Use it for **offline evaluation** (testing new model versions) or for **sampling** (checking 1% of production interactions) to keep quality high without bankrupting your API budget.
+
+### 🧑‍💻 The Everyday Prompt Engineers
+**Why you care:** This highlights a key limitation of current AI: it lies about what it did.
+**Action:** When asking an LLM to perform a complex task (like "analyze this spreadsheet"), ask it to **"show its work"** (e.g., output the Python code it used). You, the human, are the "Agent-as-a-Judge" here—don't trust the summary; verify the code or the intermediate steps.
+
+---
+
+## References
+*   [arXiv: Agent-as-a-Judge: Evaluate Agents with Agents](https://arxiv.org/abs/2410.10934)
+*   [GitHub: Agent-as-a-Judge Repository](https://github.com/metauto-ai/agent-as-a-judge) (Check for updates/code release)
+*   Related Concept: [Mixture of Experts](../concepts/mixture-of-experts.md) (Efficient models make running these heavy judge agents more viable).


### PR DESCRIPTION
Added two new articles to the knowledge base:
1.  **Foundational:** Mixture of Experts (MoE) - explaining the architecture behind models like Mixtral and DeepSeek.
2.  **Frontier:** Agent-as-a-Judge - analyzing the shift from static LLM evaluation to dynamic agentic verification.

Both articles include the required "Real-World Application & Who Should Care" sections and are cross-linked. Updated the README to index these new pages.

---
*PR created automatically by Jules for task [14238240847759745035](https://jules.google.com/task/14238240847759745035) started by @tryigit*