### PR TITLE
Add DeepSeek-R1 and Chain-of-Thought documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,14 @@
 # cleveres-ai
 A smart knowledge base about artificial intelligence.
 
+## Frontier Models
+*   [DeepSeek-R1: The Open-Source Reasoning Champion](models/deepseek-r1.md) - *The first open-weights model to rival o1 using Pure RL.*
+
 ## Frontier Research & Papers
 *   [Agent-as-a-Judge: Evaluate Agents with Agents](papers/agent-as-a-judge.md) - *Evaluating autonomous agents by using other agents to verify their process.*
 
 ## Core Concepts & Architecture
+*   [Chain-of-Thought (CoT): Eliciting Reasoning in LLMs](concepts/chain-of-thought.md) - *How models solve complex problems by "thinking" before speaking.*
 *   [Mixture of Experts (MoE): Scaling Parameters Without Scaling Costs](concepts/mixture-of-experts.md) - *How models like Mixtral and DeepSeek scale efficiently.*
 
 ## Prompt Engineering Techniques

--- a/concepts/chain-of-thought.md
+++ b/concepts/chain-of-thought.md
@@ -1,0 +1,54 @@
+# Chain-of-Thought (CoT): Eliciting Reasoning in LLMs
+
+**Category:** Foundational / Concepts
+**Key Concepts:** Intermediate Reasoning Steps, System 2 Thinking, Zero-shot CoT, Few-shot CoT
+
+## TL;DR
+Chain-of-Thought (CoT) is a technique that enables Large Language Models (LLMs) to solve complex reasoning tasks - like math word problems or common sense logic - by generating a sequence of intermediate reasoning steps. Instead of jumping directly from a question to an answer, the model is guided (or trained) to "show its work." This mimics human cognitive processes (System 2 thinking) and significantly improves performance on hard tasks.
+
+---
+
+## The Core Concept: System 2 Thinking
+Psychologist Daniel Kahneman distinguishes between two modes of thought:
+*   **System 1:** Fast, instinctive, and emotional (e.g., "What is 2+2?").
+*   **System 2:** Slow, deliberative, and logical (e.g., "What is 17 x 24?").
+
+Standard LLMs operate primarily in "System 1" mode - they predict the next token based on statistical likelihood. Chain-of-Thought forces the model into a "System 2" simulation. By generating intermediate text, the model effectively gives itself more computation time (more tokens = more time) to process the problem before committing to a final answer.
+
+## The Breakthrough: Wei et al. (2022)
+The term was popularized by the paper *"Chain-of-Thought Prompting Elicits Reasoning in Large Language Models"* by Jason Wei and colleagues at Google Brain. They found that standard prompting fails on tasks requiring multi-step logic.
+
+**Example without CoT (Standard Prompting):**
+> Q: Roger has 5 tennis balls. He buys 2 more cans of tennis balls. Each can has 3 tennis balls. How many tennis balls does he have now?
+> A: The answer is 11.
+
+**Example with CoT (Few-Shot):**
+> Q: Roger has 5 tennis balls. He buys 2 more cans of tennis balls. Each can has 3 tennis balls. How many tennis balls does he have now?
+> A: Roger started with 5 balls. 2 cans of 3 tennis balls each is 6 tennis balls. 5 + 6 = 11. The answer is 11.
+
+By providing examples of *reasoning*, the model learns to output reasoning for new problems.
+
+## Evolution: From Prompting to Training
+While CoT started as a prompting technique ("Let's think step by step"), it has now evolved into a training methodology. Modern reasoning models like **[DeepSeek-R1](../models/deepseek-r1.md)** and OpenAI's o1 are explicitly trained with Reinforcement Learning to generate long, internal Chains of Thought automatically. They don't just mimic the style; they actually use the token generation process to search for solutions and self-correct.
+
+---
+
+## Real-World Application & Who Should Care
+
+### 🚀 The Performance Monsters (SOTA Seekers)
+**Why you care:** CoT is the single most effective way to boost performance on symbolic reasoning, coding, and mathematical tasks without changing the underlying model.
+**Action:** Always implement CoT for complex tasks. If using a standard model (like GPT-4o or Claude 3.5 Sonnet), force it to outline its logic before answering. For maximum performance, switch to native reasoning models like DeepSeek-R1 that do this natively.
+
+### 💰 The Cost & Latency Optimizers (API Developers)
+**Why you care:** CoT comes with a cost. Generating reasoning steps consumes more output tokens, which increases both latency and API bills.
+**Action:** Use CoT selectively. For simple queries ("Who is the president of France?"), standard prompting is cheaper and faster. For complex logic, the extra cost of CoT is often cheaper than the cost of a wrong answer that requires retry.
+
+### 🧑‍💻 The Everyday Prompt Engineers
+**Why you care:** You can instantly upgrade the intelligence of any chatbot (ChatGPT, Claude, Gemini) with a simple magic phrase.
+**Action:** Append the phrase **"Let's think step by step"** to the end of your prompt (this is known as "Zero-shot CoT"). This simple instruction often triggers the model's reasoning capabilities without needing complex examples.
+
+---
+
+## References
+*   [Chain-of-Thought Prompting Elicits Reasoning in Large Language Models (Wei et al., 2022)](https://arxiv.org/abs/2201.11903)
+*   [Large Language Models are Zero-Shot Reasoners (Kojima et al., 2022)](https://arxiv.org/abs/2205.11916) - The origin of "Let's think step by step".

--- a/concepts/mixture-of-experts.md
+++ b/concepts/mixture-of-experts.md
@@ -39,7 +39,7 @@ In a typical setup like **Mixtral 8x7B**:
 ## Real-World Application & Who Should Care
 
 ### 🚀 The Performance Monsters (SOTA Seekers)
-**Why you care:** MoE models (like **DeepSeek-V3**, **Mixtral 8x22B**, **Grok-1**) currently offer some of the best reasoning-per-dollar ratios. They often outperform dense models of similar active parameter counts.
+**Why you care:** MoE models (like **DeepSeek-V3**, **[DeepSeek-R1](../models/deepseek-r1.md)**, **Mixtral 8x22B**, **Grok-1**) currently offer some of the best reasoning-per-dollar ratios. They often outperform dense models of similar active parameter counts.
 **Action:** When evaluating models for complex reasoning tasks, prioritize MoE architectures if you are constrained by inference latency but have sufficient VRAM. For example, frameworks like [Agent-as-a-Judge](../papers/agent-as-a-judge.md) require running many evaluations, making MoE's efficiency critical.
 
 ### 💰 The Cost & Latency Optimizers (API Developers)
@@ -47,7 +47,7 @@ In a typical setup like **Mixtral 8x7B**:
 **Action:** Adopt MoE-based endpoints (e.g., `deepseek-chat`, `mistral-small`) for high-volume background tasks. You get "big model" smarts with "small model" latency and pricing.
 
 ### 🧑‍💻 The Everyday Prompt Engineers
-**Why you care:** You might notice that MoE models sometimes feel "spiky" in their knowledge—brilliant at one topic, slightly inconsistent at another. This is a side effect of specialization.
+**Why you care:** You might notice that MoE models sometimes feel "spiky" in their knowledge - brilliant at one topic, slightly inconsistent at another. This is a side effect of specialization.
 **Action:** If an MoE model (like Mixtral) gives a weird answer, try slightly rephrasing the prompt to trigger a different set of experts. The "routing" is dynamic, so a small change in input can activate a smarter path in the model.
 
 ---

--- a/models/deepseek-r1.md
+++ b/models/deepseek-r1.md
@@ -1,0 +1,61 @@
+# DeepSeek-R1: The Open-Source Reasoning Champion
+
+**Category:** Frontier / Models
+**Key Concepts:** Reasoning Models, Pure Reinforcement Learning (RL), Group Relative Policy Optimization (GRPO), Distillation
+
+## TL;DR
+DeepSeek-R1 is a state-of-the-art reasoning model released by the Chinese lab DeepSeek. Unlike traditional LLMs that are trained primarily on next-token prediction, R1 uses a novel "Pure RL" training pipeline that encourages the model to "think" before it speaks. This allows it to self-correct and solve complex math, code, and logic problems at a level comparable to OpenAI's o1, but with fully open weights and at a fraction of the inference cost.
+
+---
+
+## How It Works: The "Pure RL" Pipeline
+DeepSeek-R1 represents a shift from "System 1" (fast, intuitive) to "System 2" (slow, deliberative) AI. Its training process is unique:
+
+### 1. The Foundation
+R1 is built on top of **DeepSeek-V3**, a massive [Mixture of Experts (MoE)](../concepts/mixture-of-experts.md) model with 671B parameters (37B active). This provides the raw knowledge base.
+
+### 2. Group Relative Policy Optimization (GRPO)
+Instead of the standard PPO (Proximal Policy Optimization) used in most RLHF pipelines, DeepSeek uses **GRPO**.
+*   **The Problem with PPO:** It requires a "Critic" model to evaluate every step, which is computationally expensive (doubles the memory cost).
+*   **The GRPO Solution:** It removes the Critic. Instead, it generates a group of outputs for the same prompt and optimizes based on the relative performance of the group. This significantly reduces training costs.
+
+### 3. Incentivizing "Thinking"
+The model is rewarded for:
+*   **Accuracy:** Did it get the right answer? (Verified by rule-based checkers for math/code).
+*   **Format:** Did it wrap its reasoning in `<think>` tags?
+
+Crucially, DeepSeek did *not* use massive amounts of human-written reasoning chains (SFT) to teach it how to think. Instead, they used a tiny "Cold Start" dataset and then let the model discover reasoning patterns on its own through RL.
+
+## The "Aha!" Moment
+During training, researchers observed emergent behaviors. The model began to:
+*   **Self-Correct:** It would generate a wrong step, pause, realize the error, and backtrack ("Wait, that calculation is wrong...").
+*   **Scan the Problem:** It started re-reading the prompt to ensure it didn't miss constraints.
+*   **Extend Thinking:** The length of its "Chain of Thought" grew from hundreds to thousands of tokens as it tackled harder problems.
+
+This is the essence of [Chain-of-Thought (CoT)](../concepts/chain-of-thought.md) reasoning, but learned autonomously rather than mimicked from human examples.
+
+## Distillation: Bringing Power to the Edge
+DeepSeek didn't just release the massive 671B model. They "distilled" the reasoning patterns of R1 into smaller, denser models (like Llama-3 and Qwen-2.5 based versions).
+*   **Result:** You can run a 7B or 8B parameter model on a laptop that has reasoning capabilities far surpassing its size class.
+
+---
+
+## Real-World Application & Who Should Care
+
+### 🚀 The Performance Monsters (SOTA Seekers)
+**Why you care:** R1 rivals OpenAI's o1-preview on benchmarks like AIME (math) and Codeforces (coding). It is the current king of open-weights reasoning.
+**Action:** Use R1 (or the API) for complex tasks where standard LLMs hallucinate: advanced mathematics, theorem proving, complex competitive programming, and agentic planning.
+
+### 💰 The Cost & Latency Optimizers (API Developers)
+**Why you care:** The DeepSeek API is aggressively priced (approx. $0.55 / 1M input tokens). This is orders of magnitude cheaper than OpenAI's o1.
+**Action:** Replace expensive reasoning calls with DeepSeek-R1. For even lower latency, use the "distilled" small models (e.g., DeepSeek-R1-Distill-Llama-8B) for on-device applications or high-throughput microservices.
+
+### 🧑‍💻 The Everyday Prompt Engineers
+**Why you care:** R1 exposes its "inner monologue." You can see *how* the model arrived at an answer by reading the content inside the `<think>` tags.
+**Action:** If the model gets a question wrong, read the `<think>` section. You will often see exactly where it misunderstood your prompt, allowing you to fix your instructions with surgical precision.
+
+---
+
+## References
+*   [DeepSeek-R1: Incentivizing Reasoning Capability in LLMs via Reinforcement Learning (DeepSeek AI, 2025)](https://github.com/deepseek-ai/DeepSeek-R1)
+*   [DeepSeek-V3 Technical Report (DeepSeek AI, 2024)](https://github.com/deepseek-ai/DeepSeek-V3)


### PR DESCRIPTION
Added DeepSeek-R1 (Frontier) and Chain-of-Thought (Foundational) documentation, cross-linked them, and updated the index. Verified formatting and style guidelines.

---
*PR created automatically by Jules for task [17725520603951052314](https://jules.google.com/task/17725520603951052314) started by @tryigit*