### PR TITLE
Add Inference-Time Compute, o3-mini, and Context Caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A smart knowledge base about artificial intelligence.
 *   [Qwen 2.5-VL: The Vision-Language Flagship](models/qwen-2-5-vl.md) - *A multimodal model for native dynamic resolution, long-video comprehension, and visual agent tasks.*
 *   [DeepSeek-R1: The Open-Source Reasoning Champion](models/deepseek-r1.md) - *The first open-weights model to rival o1 using Pure RL.*
 *   [DeepSeek-V3: The Open-Source Titan Behind R1](models/deepseek-v3.md) - *The 671B MoE base model for R1 with innovative MLA and DeepSeekMoE.*
+*   [OpenAI o3-mini: High-Speed Reasoning for the Masses](models/o3-mini.md) - *A fast, cost-efficient reasoning model tailored for STEM and coding tasks.*
 
 ## Frontier Research & Papers
 *   [Agent-as-a-Judge: Evaluate Agents with Agents](papers/agent-as-a-judge.md) - *Evaluating autonomous agents by using other agents to verify their process.*
@@ -14,8 +15,10 @@ A smart knowledge base about artificial intelligence.
 *   [Transformer Architecture: The Engine of Modern AI](concepts/transformer-architecture.md) - *The core mechanism behind GPT, BERT, and most modern LLMs using Self-Attention.*
 *   [Chain-of-Thought (CoT): Eliciting Reasoning in LLMs](concepts/chain-of-thought.md) - *How models solve complex problems by "thinking" before speaking.*
 *   [Mixture of Experts (MoE): Scaling Parameters Without Scaling Costs](concepts/mixture-of-experts.md) - *How models like Mixtral and DeepSeek scale efficiently.*
+*   [Inference-Time Compute: The New Scaling Law](concepts/inference-time-compute.md) - *Shift from training-time scale to test-time reasoning (System 2 thinking).*
 
 ## Prompt Engineering Techniques
+*   [Context Caching: The Cost-Cutting Superpower](techniques/context-caching.md) - *Reducing cost and latency by reusing the KV cache for large prompts.*
 *   [Double Question Prompting: Overcoming Causal LLM Limitations](techniques/double-question-prompting.md)
 
 ## Telegram

--- a/concepts/inference-time-compute.md
+++ b/concepts/inference-time-compute.md
@@ -1,0 +1,55 @@
+# Inference-Time Compute: The New Scaling Law (System 2 Thinking)
+
+## TL;DR
+**Inference-Time Compute** (also known as Test-Time Compute) is a paradigm shift where models are given more time to "think" before generating a final answer. Instead of just scaling model parameters during training (Training-Time Compute), this approach scales the computation used *during generation* to explore multiple reasoning paths, self-correct, and verify answers. Models like **OpenAI o1** and **[DeepSeek-R1](../models/deepseek-r1.md)** exemplify this shift.
+
+---
+
+## The Concept: From Training Scale to Test-Time Scale
+
+For years, the AI field was dominated by **Kaplan's Scaling Laws**, which stated that model performance improves predictably as you increase model size (parameters), dataset size, and training compute. This led to the era of massive models like GPT-4 and Gemini Ultra.
+
+However, researchers found that for complex reasoning tasks (math, coding, logic), simply making the model bigger yields diminishing returns. Instead, allowing a smaller model to "think longer" can often outperform a much larger model that answers instantly.
+
+### System 1 vs. System 2 Thinking
+*   **System 1 (Fast):** Traditional LLMs (GPT-4, Claude 3.5 Sonnet) operate like human intuition. They generate tokens sequentially, token-by-token, without backtracking or pausing. If the first token is wrong, the entire answer might be flawed.
+*   **System 2 (Slow):** Inference-time compute models mimic deliberate human reasoning. They pause, plan, critique their own steps, and explore alternatives before outputting a solution. This is often implemented via **[Chain-of-Thought (CoT)](chain-of-thought.md)** or hidden "thought tokens."
+
+---
+
+## How It Works: Thought Tokens & Search
+
+When you prompt a model like o1 or R1, it doesn't just predict the next word. It generates thousands of internal "thought tokens" that are hidden from the user.
+
+1.  **Exploration:** The model generates multiple potential paths to a solution.
+2.  **Verification:** It checks intermediate steps for errors (e.g., "Wait, that calculation is wrong because...").
+3.  **Backtracking:** If a path leads to a dead end, it discards it and tries another strategy.
+4.  **Final Output:** Once confident, it summarizes the reasoning into a concise answer.
+
+This process essentially turns inference into a **search problem** (like AlphaGo searching for the best move), trading time for accuracy.
+
+---
+
+## Real-World Application & Who Should Care
+
+### 🚀 For The Performance Monsters (SOTA Seekers)
+This is the only way to solve "impossible" problems.
+*   **Hard Math & Code:** Use inference-time compute models for competitive programming (Codeforces), Olympiad math (AIME), or complex architectural design where a single error breaks the whole system.
+*   **Agentic Planning:** Use these models as the "brain" for autonomous agents to plan multi-step workflows before executing actions.
+
+### 💰 For The Cost & Latency Optimizers (API Developers)
+Be careful—this gets expensive fast.
+*   **Latency Trade-off:** These models can take 10-60 seconds to reply. Do **not** use them for customer-facing chatbots requiring instant responses.
+*   **Cost Control:** "Thinking" consumes tokens. A simple "Hello" might generate 500 hidden thought tokens. Use strict `max_completion_tokens` limits or stick to standard models (System 1) for routine tasks.
+
+### 🧑‍💻 For The Everyday Prompt Engineers
+You don't need to prompt these models to "think step by step"—they already do.
+*   **Simpler Prompts:** You can use simpler prompts. Instead of complex CoT engineering, just state the problem clearly.
+*   **Show Your Work:** While the thought process is often hidden, you can ask the model to "explain the reasoning" in the final output if you need to debug its logic.
+
+---
+
+## References
+*   [Scaling Laws for Neural Language Models (Kaplan et al.)](https://arxiv.org/abs/2001.08361) - The original training scaling laws.
+*   [Let's Verify Step by Step](https://arxiv.org/abs/2305.20050) - OpenAI research on process supervision.
+*   [DeepSeek-R1 Technical Report](../models/deepseek-r1.md) - Practical implementation of inference-time scaling.

--- a/models/o3-mini.md
+++ b/models/o3-mini.md
@@ -1,0 +1,50 @@
+# OpenAI o3-mini: High-Speed Reasoning for the Masses
+
+## TL;DR
+**o3-mini** (released Jan 2025) is OpenAI's latest cost-efficient reasoning model. It brings the powerful "System 2" thinking capabilities of the **o1 series** to a much faster and cheaper package. It is designed for STEM (Science, Technology, Engineering, Math) tasks, coding, and complex logic, but lacks vision capabilities.
+
+---
+
+## Key Specs & Features
+
+*   **Context Window:** 200,000 tokens (input), 100,000 tokens (output).
+*   **Pricing:** ~$1.10 / 1M input tokens, ~$4.40 / 1M output tokens (approx. 93% cheaper than the original o1-preview).
+*   **Speed:** significantly faster than o1 due to a smaller, more optimized architecture.
+*   **Reasoning:** Uses reinforcement learning to "think" before answering, similar to **[DeepSeek-R1](deepseek-r1.md)**.
+*   **Limitations:** No vision support (text-only). No fine-tuning (yet).
+
+---
+
+## Comparison: o3-mini vs. DeepSeek-R1
+
+| Feature | OpenAI o3-mini | DeepSeek-R1 |
+| :--- | :--- | :--- |
+| **Architecture** | Dense Transformer (Likely) | Mixture-of-Experts (MoE) |
+| **Access** | API (Closed Source) | Open Weights (MIT License) |
+| **Thinking Style** | Hidden thought tokens | Visible or Hidden thought tokens |
+| **Cost** | Low ($1.10 / $4.40) | Ultra-Low (API) or Free (Self-Hosted) |
+| **Best For** | Enterprise workflows, reliable API usage | Research, privacy-sensitive local deployment |
+
+---
+
+## Real-World Application & Who Should Care
+
+### 🚀 For The Performance Monsters (SOTA Seekers)
+While "mini" implies smaller, don't underestimate it.
+*   **Coding Agent:** o3-mini is excellent at autonomously writing and debugging code. Its 100k output token limit allows it to generate entire files or modules in one go.
+*   **Math Competitions:** It scores exceptionally well on AIME and Codeforces, often rivaling much larger models.
+
+### 💰 For The Cost & Latency Optimizers (API Developers)
+This is the model you've been waiting for to replace GPT-4o for logic tasks.
+*   **Cheap Reasoning:** If your application requires multi-step logic (e.g., parsing unstructured data into JSON), o3-mini is far more reliable than GPT-4o-mini and much cheaper than o1.
+*   **Context Caching:** Combine o3-mini with **Context Caching** (50% discount on cached inputs) to build affordable, long-context RAG applications.
+
+### 🧑‍💻 For The Everyday Prompt Engineers
+*   **STEM Assistant:** Use it for homework help, explaining complex physics concepts, or debugging your Python scripts.
+*   **No "Prompt Engineering":** Like other reasoning models, it works best with simple, direct instructions. It will figure out the "how" on its own.
+
+---
+
+## References
+*   [OpenAI o3-mini Announcement](https://openai.com/index/openai-o3-mini/) - Official release notes.
+*   [Inference-Time Compute](../concepts/inference-time-compute.md) - Understanding how reasoning models work.

--- a/techniques/context-caching.md
+++ b/techniques/context-caching.md
@@ -1,0 +1,52 @@
+# Context Caching: The Cost-Cutting Superpower for Long-Context AI
+
+## TL;DR
+**Context Caching** is a technique that allows developers to store (cache) the processed state (KV Cache) of a large prompt prefix—such as a system instruction, a long document, or a codebase—and reuse it across multiple API calls. Instead of paying to re-process the same 50,000 tokens for every user request, you only pay once to cache it, and then pay a heavily discounted rate (often 50-90% off) for subsequent hits.
+
+---
+
+## How It Works: Static vs. Dynamic Prompts
+
+In a typical LLM call, the prompt is processed from scratch every time. With Context Caching, you split your prompt into two parts:
+
+1.  **Static Prefix (Cached):** The part that doesn't change.
+    *   *Examples:* A 100-page policy document, a "persona" definition for a role-playing bot, or a large set of few-shot examples.
+2.  **Dynamic Suffix (User Query):** The part that is unique to each request.
+    *   *Examples:* "Summarize section 3," "Does this policy cover flood damage?", or "Translate this sentence."
+
+When a request comes in, the API checks if the static prefix is already in the cache (hit). If so, it skips processing those tokens entirely, saving both **compute (latency)** and **money**.
+
+---
+
+## Supported Providers & Pricing Models (Typical)
+
+Most major providers now support some form of context caching:
+*   **Anthropic (Claude 3.5 Sonnet/Haiku):** explicitly marks "cache breakpoints." ~90% discount on cache hits.
+*   **OpenAI (GPT-4o, o1, o3-mini):** automatic caching for recent requests. ~50% discount on cache hits.
+*   **Google (Gemini 1.5 Pro/Flash):** explicit context caching API. Huge savings for million-token contexts.
+*   **DeepSeek (V3/R1):** automatic prefix caching at the API level (DiskCache). Extremely low cost for hits.
+
+---
+
+## Real-World Application & Who Should Care
+
+### 🚀 For The Performance Monsters (SOTA Seekers)
+Latency is key.
+*   **Interactive Agents:** If your agent has a 50k-token "memory" or "instruction manual," caching it means the user doesn't have to wait 10 seconds for the model to re-read it every turn. Responses feel instant.
+*   **Coding Assistants:** Cache the entire repository structure so the model understands the full project context without re-ingesting it for every small code change.
+
+### 💰 For The Cost & Latency Optimizers (API Developers)
+This is mandatory for production RAG systems.
+*   **RAG Optimization:** Instead of retrieving small chunks, you can cache a larger set of relevant documents.
+*   **Few-Shot Prompting:** You can now afford to include 100+ examples in your prompt (which massively improves quality) because you only pay for them once, not every call.
+
+### 🧑‍💻 For The Everyday Prompt Engineers
+While mostly an API feature, understanding it helps you design better system prompts.
+*   **Front-Load Context:** Put all your heavy instructions, rules, and reference material at the *start* of the conversation. This maximizes the chance that the system can cache that block.
+*   **Structure Matters:** Keep your system prompts stable. Changing even one character in the prefix breaks the cache for everyone.
+
+---
+
+## References
+*   [Anthropic Prompt Caching Guide](https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching) - Detailed implementation guide.
+*   [Retrieval-Augmented Generation (RAG)](../concepts/retrieval-augmented-generation.md) - Context caching is a powerful alternative or companion to RAG.


### PR DESCRIPTION
Added three new high-quality articles covering:
1.  **Inference-Time Compute:** The foundational shift from training scale to test-time reasoning.
2.  **OpenAI o3-mini:** A frontier model analysis focusing on specs, cost, and use cases.
3.  **Context Caching:** A practical technique for optimizing API usage.

All articles include the mandatory "Real-World Application" section targeting Performance Monsters, Cost Optimizers, and Everyday Prompt Engineers. Cross-links are established between new and existing files.

---
*PR created automatically by Jules for task [4170857219845951199](https://jules.google.com/task/4170857219845951199) started by @tryigit*