### PR TITLE
feat(concept): add direct preference optimization article

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A smart knowledge base about artificial intelligence.
 *   [Agent-as-a-Judge: Evaluate Agents with Agents](papers/agent-as-a-judge.md) - *Evaluating autonomous agents by using other agents to verify their process.*
 
 ## Core Concepts & Architecture
+*   [Direct Preference Optimization (DPO)](concepts/direct-preference-optimization.md) - *A lightweight alternative to RLHF that turns the language model itself into a reward model via contrastive pairs.*
 *   [Group Relative Policy Optimization (GRPO): Efficient Reinforcement Learning](concepts/group-relative-policy-optimization.md) - *Streamlining RL by eliminating the value model and using group-based reward baselines.*
 *   [Low-Rank Adaptation (LoRA): Efficient Fine-Tuning](concepts/low-rank-adaptation.md) - *Fine-tuning massive models efficiently by injecting small, trainable rank decomposition matrices.*
 *   [Retrieval-Augmented Generation (RAG): Bridging Knowledge and Generation](concepts/retrieval-augmented-generation.md) - *Reducing hallucinations by grounding model outputs in external data.*

--- a/concepts/direct-preference-optimization.md
+++ b/concepts/direct-preference-optimization.md
@@ -1,0 +1,45 @@
+# Direct Preference Optimization (DPO)
+
+**Category:** Core Concepts & Architecture
+**Key Concepts:** Alignment, Reinforcement Learning from Human Feedback (RLHF), Supervised Fine-Tuning (SFT)
+
+## TL;DR
+**Direct Preference Optimization (DPO)** is a lightweight alternative to Reinforcement Learning from Human Feedback (RLHF) for aligning Large Language Models (LLMs) to human preferences. Introduced in a 2023 paper, DPO fundamentally simplifies the alignment process. Instead of needing to train an entirely separate reward model (a "critic") and employing complex reinforcement learning algorithms like PPO, DPO optimizes the LLM directly on preference data using a simple binary cross-entropy loss objective. It turns the language model itself into a reward model, making fine-tuning significantly simpler, faster, and more memory-efficient.
+
+---
+
+## How DPO Differs from RLHF
+
+Traditionally, tuning a pre-trained LLM requires three major steps:
+1.  **Supervised Fine-Tuning (SFT):** Training the model on high-quality prompt/response pairs.
+2.  **Reward Model Training:** Training a separate model to score responses based on human preference.
+3.  **RL Optimization:** Using an algorithm like PPO to adjust the LLM so it generates responses that the reward model scores highly.
+
+DPO drastically simplifies this by skipping the reward model training phase entirely.
+
+### 1. No Separate Reward Model
+In RLHF, you must train and host a separate reward model alongside the primary LLM during training. DPO eliminates this requirement. It treats the language model itself as the reward model, extracting an implicit reward function directly from the LLM's own probability distribution. This cuts the memory footprint and the complexity of the training pipeline dramatically.
+
+### 2. Direct Optimization via Binary Data
+Instead of a continuous reward score, DPO requires "preference data". This means given a prompt, you simply provide a "preferred response" (the winning completion) and a "non-preferred response" (the losing completion). The model uses a contrastive loss function to directly adjust its weights: increasing the probability of generating the preferred response and decreasing the probability of the non-preferred response.
+
+---
+
+## Real-World Application & Who Should Care
+
+### 🚀 For The Performance Monsters (SOTA Seekers)
+**Why you care:** DPO is mathematically proven to be as effective as standard RLHF methods (and often more stable during training), without the overhead of tuning hyper-parameters for a complex RL loop.
+**Action:** When fine-tuning highly specialized models where subjective tone, style, or specific formatting is critical, use DPO. It provides a more robust and less volatile training experience than PPO-based RLHF.
+
+### 💰 For The Cost & Latency Optimizers (API Developers)
+**Why you care:** Training an LLM using RLHF requires vast computational resources due to multiple models being active simultaneously. DPO requires fewer hardware resources, making it cheaper and faster to run alignment training jobs.
+**Action:** If you are building custom aligned models for internal APIs or specific customer use cases, adopting DPO reduces your training compute costs and speeds up iteration cycles.
+
+### 🧑‍💻 For The Everyday Prompt Engineers
+**Why you care:** DPO's rise means the open-source community is producing high-quality, aligned models much faster than before. Organizations no longer need massive compute clusters to align a model to user preferences.
+**Action:** Recognize that models tagged with "DPO" in their name (e.g., Llama-3-8B-Instruct-DPO) have been tuned on direct contrastive pairs. This often results in a model that is more compliant, less repetitive, and better aligned with expected human conversational norms compared to simple SFT models.
+
+---
+
+## References
+*   [Direct Preference Optimization: Your Language Model is Secretly a Reward Model (arXiv)](https://arxiv.org/abs/2305.18290)

--- a/concepts/group-relative-policy-optimization.md
+++ b/concepts/group-relative-policy-optimization.md
@@ -10,7 +10,7 @@ Group Relative Policy Optimization (GRPO) is a reinforcement learning (RL) algor
 
 ## How GRPO Works: Simplifying Reinforcement Learning
 
-Traditional reinforcement learning methods used for tuning Large Language Models (LLMs), like PPO, typically require maintaining two distinct neural networks during training:
+Traditional reinforcement learning methods used for tuning Large Language Models (LLMs), like PPO, typically require maintaining two distinct neural networks during training (Note: another lightweight alternative to RLHF is **[Direct Preference Optimization (DPO)](../concepts/direct-preference-optimization.md)**):
 1.  **The Actor (Policy Model):** The model generating the responses.
 2.  **The Critic (Value Model):** A model trained alongside the actor to evaluate how good the generated responses are.
 


### PR DESCRIPTION
Added a new foundational article on Direct Preference Optimization (DPO) under the `concepts` directory. DPO is a significant alternative to RLHF in AI model alignment. The article follows repository standards including a TL;DR, a "Real-World Application & Who Should Care" section, and avoids long em-dashes. I also added a cross-link referencing DPO from the existing GRPO article and updated `README.md`'s Core Concepts & Architecture section.

---
*PR created automatically by Jules for task [4044446740978513286](https://jules.google.com/task/4044446740978513286) started by @tryigit*