### PR TITLE
feat(technique): add speculative decoding for inference optimization

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ A smart knowledge base about artificial intelligence.
 ## Prompt Engineering Techniques
 *   [Context Caching: The Cost-Cutting Superpower](techniques/context-caching.md) - *Reducing cost and latency by reusing the KV cache for large prompts.*
 *   [Double Question Prompting: Overcoming Causal LLM Limitations](techniques/double-question-prompting.md)
+*   [Speculative Decoding](techniques/speculative-decoding.md) - *Accelerating LLM inference by pairing a small draft model with a larger verification model.*
 
 ## Telegram
 * [CleveresTech Telegram Group](t.me/cleverestech)

--- a/concepts/inference-time-compute.md
+++ b/concepts/inference-time-compute.md
@@ -38,12 +38,12 @@ This is the only way to solve "impossible" problems.
 *   **Agentic Planning:** Use these models as the "brain" for autonomous agents to plan multi-step workflows before executing actions.
 
 ### 💰 For The Cost & Latency Optimizers (API Developers)
-Be careful—this gets expensive fast.
-*   **Latency Trade-off:** These models can take 10-60 seconds to reply. Do **not** use them for customer-facing chatbots requiring instant responses.
+Be careful - this gets expensive fast.
+*   **Latency Trade-off:** These models can take 10-60 seconds to reply. Do **not** use them for customer-facing chatbots requiring instant responses. If you need fast generation for standard models, look into techniques like [Speculative Decoding](../techniques/speculative-decoding.md).
 *   **Cost Control:** "Thinking" consumes tokens. A simple "Hello" might generate 500 hidden thought tokens. Use strict `max_completion_tokens` limits or stick to standard models (System 1) for routine tasks.
 
 ### 🧑‍💻 For The Everyday Prompt Engineers
-You don't need to prompt these models to "think step by step"—they already do.
+You don't need to prompt these models to "think step by step" - they already do.
 *   **Simpler Prompts:** You can use simpler prompts. Instead of complex CoT engineering, just state the problem clearly.
 *   **Show Your Work:** While the thought process is often hidden, you can ask the model to "explain the reasoning" in the final output if you need to debug its logic.
 

--- a/techniques/speculative-decoding.md
+++ b/techniques/speculative-decoding.md
@@ -1,0 +1,47 @@
+# Speculative Decoding: Breaking the Autoregressive Bottleneck
+
+## TL;DR
+**Speculative Decoding** is an inference optimization technique that accelerates Large Language Model (LLM) generation without compromising output quality. It works by pairing a smaller, faster "draft" model to guess upcoming tokens with a larger, more powerful "target" model to verify them in parallel. This breaks the sequential bottleneck of standard autoregressive generation, often yielding 2x to 3x speedups.
+
+---
+
+## The Problem: The Autoregressive Bottleneck
+
+Traditional LLMs generate text **autoregressively**, meaning they produce one token at a time. Each new token requires a full forward pass through the entire neural network, reloading massive weight matrices into the GPU's memory.
+Because GPUs are designed for massive parallel processing, generating just one token leaves much of the hardware's compute capacity idle. The process becomes memory-bound, leading to high latency and underutilized resources.
+
+## How Speculative Decoding Works
+
+Speculative decoding transforms text generation from a strictly sequential process into a parallel one using a "draft and verify" approach.
+
+### 1. Draft Generation
+A much smaller, lightweight model (the "draft model") quickly generates a sequence of potential next tokens. Because this model is small, it can predict several tokens in the time it takes the large model to predict just one. For example, a 2B parameter model might draft 5 tokens for a 70B parameter target model.
+
+### 2. Parallel Verification
+The large, highly accurate model (the "target model") then takes this drafted sequence and processes all the tokens simultaneously in a single forward pass. It computes the probabilities for each drafted token to verify if they match what it would have generated itself.
+
+### 3. Acceptance and Correction
+*   **Acceptance:** If the target model agrees with the draft model's predictions, those tokens are accepted and immediately added to the final output.
+*   **Correction:** The moment the target model disagrees with a drafted token, it rejects that token and all subsequent ones in the draft sequence. It then generates the correct token itself, and the process restarts.
+
+Because the target model retains the final say, the output mathematically matches the exact distribution of the large model. You get the speed of a small model with the quality of a large model.
+
+---
+
+## Real-World Application & Who Should Care
+
+### 🚀 For The Performance Monsters (SOTA Seekers)
+If you are running massive, unquantized models (like Llama 3 70B or DeepSeek-V3) locally or on dedicated hardware, speculative decoding is essential. It allows you to dramatically increase token generation speed, enabling near real-time interactions for complex reasoning tasks that would otherwise feel sluggish.
+
+### 💰 For The Cost & Latency Optimizers (API Developers)
+This is a game changer for system architecture. By implementing speculative decoding, you can serve more users on the same hardware, increasing throughput and driving down compute costs. It is especially useful for high-traffic applications where reducing Time-to-First-Token (TTFT) and increasing tokens-per-second is critical for user retention. However, you must carefully select a draft model that aligns well with your target model to ensure high acceptance rates, otherwise the overhead of the draft model might negate the benefits.
+
+### 🧑‍💻 For The Everyday Prompt Engineers
+While you do not implement speculative decoding directly in your prompts, it impacts the tools you use. If you notice a sudden, massive speedup in your favorite web interfaces (like ChatGPT or Claude) without a drop in reasoning quality, you are likely experiencing speculative decoding or similar inference optimizations behind the scenes. You can continue writing complex prompts knowing the backend is optimized to handle them swiftly.
+
+---
+
+## References
+*   [Fast Inference from Transformers via Speculative Decoding (Leviathan et al.)](https://arxiv.org/abs/2211.17192) - Foundational paper on the technique.
+*   [Accelerating Large Language Model Decoding with Speculative Sampling (Chen et al.)](https://arxiv.org/abs/2302.01318) - DeepMind research on speculative sampling.
+*   [Speculative Decoding: A Guide With Implementation Examples (DataCamp)](https://www.datacamp.com/tutorial/speculative-decoding) - Practical guide and implementation details.


### PR DESCRIPTION
Adds a new article on Speculative Decoding in the `techniques` directory.
Cross-links Speculative Decoding in `concepts/inference-time-compute.md`.
Replaces forbidden long em-dashes with hyphens in `concepts/inference-time-compute.md`.
Updates `README.md` index with the new technique.

---
*PR created automatically by Jules for task [1659089546203826072](https://jules.google.com/task/1659089546203826072) started by @tryigit*