### PR TITLE
feat(concept): add Multi-Head Latent Attention (MLA) deep dive

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ A smart knowledge base about artificial intelligence.
 *   [Rotary Position Embedding (RoPE)](concepts/rotary-position-embedding.md) - *Injecting relative positional information by mathematically rotating token embeddings in space.*
 *   [Quantization: Shrinking Models for the Real World](concepts/quantization.md) - *Reducing model weights to lower precision formats (e.g., INT4) to drastically cut VRAM requirements with minimal accuracy loss.*
 *   [FlashAttention: IO-Aware Exact Attention](concepts/flash-attention.md) - *A memory-efficient algorithm that reduces HBM/SRAM access overhead, turning quadratic memory complexity into linear.*
+*   [Multi-Head Latent Attention (MLA): Compressing the KV Cache](concepts/multi-head-latent-attention.md) - *A low-rank factorization technique that shrinks KV cache size drastically, enabling longer context sizes and faster inference in DeepSeek models.*
 
 ## Prompt Engineering Techniques
 *   [Context Caching: The Cost-Cutting Superpower](techniques/context-caching.md) - *Reducing cost and latency by reusing the KV cache for large prompts.*

--- a/concepts/multi-head-latent-attention.md
+++ b/concepts/multi-head-latent-attention.md
@@ -1,0 +1,61 @@
+# Multi-Head Latent Attention (MLA): Compressing the KV Cache
+
+## TL;DR
+Multi-Head Latent Attention (MLA) is a highly efficient attention mechanism introduced by DeepSeek (in DeepSeek-V2 and utilized in **[DeepSeek-V3](../models/deepseek-v3.md)** and R1). It drastically reduces the memory footprint of the KV Cache during text generation by using low-rank factorization to compress the Key and Value matrices into a single, much smaller latent vector. This allows models to handle significantly larger context windows and batch sizes without running out of memory.
+
+---
+
+## The Problem: The KV Cache Bottleneck
+In a standard **[Transformer Architecture](../concepts/transformer-architecture.md)**, the model predicts text one token at a time (autoregressive generation). To do this efficiently, the model caches the calculated "Keys" (K) and "Values" (V) for all previous tokens in the sequence. This is called the KV Cache.
+
+Without the KV Cache, the model would have to recalculate the entire history for every single new word. However, as the context window grows (e.g., to 128k or 1M tokens) or as batch sizes increase (serving multiple users), the KV Cache consumes a massive amount of VRAM (GPU Memory). Often, the KV Cache becomes larger than the model weights themselves, creating a severe memory bottleneck.
+
+### Previous Attempts to Fix It
+Before MLA, researchers tried to shrink the KV Cache with two main techniques:
+1.  **Multi-Query Attention (MQA):** Instead of having a separate K and V for every "attention head" (which Multi-Head Attention or MHA does), MQA forces all query heads to share a *single* K and V head. This saves massive amounts of memory but can degrade the model's reasoning quality.
+2.  **Grouped-Query Attention (GQA):** A middle ground used in models like Llama 2/3. Query heads are grouped together, and each group shares one K and V head. It balances memory savings with model quality.
+
+## The Solution: Multi-Head Latent Attention (MLA)
+MLA takes a completely different approach. Instead of just reducing the *number* of K and V heads, it compresses the data itself.
+
+### 1. Low-Rank Factorization (The Compression)
+In standard attention, Keys and Values are large, high-dimensional vectors. MLA uses a technique called "low-rank factorization." It takes the large projection matrix and splits it into two smaller matrices.
+
+During inference, instead of computing and caching the full-sized K and V vectors for every token, MLA projects the token's information down into a much smaller, compressed "latent vector."
+
+*   **Caching the Latent Vector:** Only this tiny latent vector is stored in the KV Cache, reducing the memory footprint by up to 93% compared to standard MHA.
+*   **Decompression on the Fly:** When the model needs to calculate attention, it takes the compressed latent vector from the cache and rapidly "decompresses" it back into the full K and V heads using an up-projection matrix.
+
+### 2. Decoupled RoPE (Handling Position)
+There is a catch. Modern LLMs use **[Rotary Position Embedding (RoPE)](../concepts/rotary-position-embedding.md)** to keep track of word order. RoPE applies mathematical rotations to the Keys and Queries.
+
+If you compress the Keys into a latent vector, applying the RoPE rotation becomes mathematically destructive or extremely complex upon decompression.
+
+To solve this, MLA uses **Decoupled RoPE**. It splits the Query and Key vectors into two parts:
+1.  **Content Part:** This part carries the semantic meaning and is compressed using the low-rank latent vector.
+2.  **Positional Part (RoPE Part):** This is a small, separate vector dedicated entirely to carrying the RoPE positional information. This part is *not* compressed.
+
+During the attention calculation, the decompressed content part and the uncompressed positional part are recombined, allowing MLA to work perfectly with RoPE while still achieving massive compression.
+
+---
+
+## Real-World Application & Who Should Care
+
+### 🚀 For The Performance Monsters (SOTA Seekers)
+MLA is the secret sauce that allows DeepSeek models to maintain high capability without buckling under their own weight.
+*   **Long-Context Reasoning:** If you are building agents that need to process 100k+ token codebases or books, MLA allows the model to "remember" all that context without needing an impossible amount of VRAM. It scales inference capability linearly where older models failed quadratically.
+
+### 💰 For The Cost & Latency Optimizers (API Developers)
+MLA is arguably the most important architectural shift for cost reduction in the past year.
+*   **Massive Batch Sizes:** Because the KV cache per user is so tiny, you can pack significantly more concurrent requests onto a single GPU. This directly translates to the incredibly cheap API costs seen with providers running DeepSeek-V3.
+*   **Context Caching Economics:** When using "Context Caching" (saving a long prompt to reuse across multiple calls), the storage cost of that cache is minimal with MLA compared to standard models, making RAG (Retrieval-Augmented Generation) at scale much cheaper.
+
+### 🧑‍💻 For The Everyday Prompt Engineers
+While MLA runs under the hood, it changes how you can interact with the model.
+*   **Mega-Prompts:** You can confidently paste entire manuals, thousands of lines of code, or long chat histories into models utilizing MLA (like DeepSeek R1/V3) without worrying as much about the provider rejecting the prompt due to context limits or charging exorbitant fees. The model is built to digest massive inputs efficiently.
+
+---
+
+## References
+*   [DeepSeek-V2 Technical Report](https://arxiv.org/abs/2405.04434) - The paper introducing MLA.
+*   [DeepSeek-V3 Technical Report](https://github.com/deepseek-ai/DeepSeek-V3/blob/main/DeepSeek_V3.pdf) - Further refinement and deployment of MLA at scale.

--- a/models/deepseek-v3.md
+++ b/models/deepseek-v3.md
@@ -8,7 +8,7 @@
 ## The Architecture: Efficiency at Scale
 DeepSeek-V3 builds on the standard **[Transformer Architecture](../concepts/transformer-architecture.md)** but introduces several critical innovations to maximize efficiency and performance.
 
-### 1. Multi-Head Latent Attention (MLA)
+### 1. [Multi-Head Latent Attention (MLA)](../concepts/multi-head-latent-attention.md)
 Standard Transformers suffer from a large KV Cache, which consumes massive amounts of VRAM during generation. MLA compresses the Key-Value (KV) cache into a latent vector, reducing memory usage by up to 93% compared to standard MHA. This allows V3 to serve much longer contexts and larger batch sizes on the same hardware.
 
 ### 2. DeepSeekMoE (Fine-Grained Experts)


### PR DESCRIPTION
This submission adds a new core concept file `concepts/multi-head-latent-attention.md` explaining Multi-Head Latent Attention (MLA).

The article includes a TL;DR, explains the KV Cache bottleneck, contrasts MLA with MQA/GQA, and details low-rank factorization and Decoupled RoPE.
It also includes the required "Real-World Application & Who Should Care" sections with emojis, avoids long em-dashes, and adds cross-links.

Additionally, the `README.md` and `models/deepseek-v3.md` files have been updated to link to this new concept, maintaining the interconnected wiki structure.

---
*PR created automatically by Jules for task [9706908032820158636](https://jules.google.com/task/9706908032820158636) started by @tryigit*