### PR TITLE
feat(model): add Grok 3 analysis and update index

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 A smart knowledge base about artificial intelligence.
 
 ## Frontier Models
+*   [Grok 3: The Age of Reasoning Agents](models/grok-3.md) - *xAI's newest frontier model focusing on test-time compute and advanced mathematical reasoning.*
 *   [GLM-5: The 744B Frontier MoE Model](models/glm-5.md) - *Zhipu AI's flagship open-weights model featuring DeepSeek Sparse Attention and asynchronous RL for complex agentic tasks.*
 *   [Claude 3.7 Sonnet: The Hybrid Reasoning Engine](models/claude-3-7-sonnet.md) - *Anthropic's hybrid model that toggles between instant responses and extended thinking.*
 *   [Wan 2.1: The Open-Source Video Generator](models/wan-2-1.md) - *Alibaba's 14B parameter video generation model with advanced motion control.*

--- a/check_links.sh
+++ b/check_links.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-files="README.md papers/areal.md papers/flash-attention-4.md concepts/group-relative-policy-optimization.md concepts/flash-attention.md"
+files="models/grok-3.md README.md papers/areal.md papers/flash-attention-4.md concepts/group-relative-policy-optimization.md concepts/flash-attention.md"
 for file in $files; do
   echo "Checking links in $file"
   # extract links that look like (relative/path.md)

--- a/models/grok-3.md
+++ b/models/grok-3.md
@@ -1,0 +1,29 @@
+# Grok 3 Beta: The Age of Reasoning Agents
+
+**TL;DR:** Grok 3 by xAI is a frontier AI model focusing on superior reasoning abilities and extensive pretraining knowledge. Released in Beta, it features an advanced "Think" mode that leverages massive test-time compute to solve complex problems, recently scoring an impressive 93.3% on the 2025 American Invitational Mathematics Examination (AIME).
+
+## Overview
+
+Announced in February 2025, Grok 3 represents xAI's most advanced model to date. The system is designed not just to recall knowledge but to actively reason through complex scenarios. Its primary differentiator is its aggressive use of compute during the generation phase to explore, verify, and select the best possible answers.
+
+## Architecture & Capabilities
+
+While full architectural details remain proprietary, Grok 3 heavily utilizes [Inference-Time Compute](../concepts/inference-time-compute.md). This paradigm shifts computational load from the pre-training phase directly to the inference phase. By allowing the model to "think" for extended periods before returning an answer, Grok 3 can dynamically allocate resources based on the complexity of the prompt.
+
+*   **Mathematical Reasoning:** Grok 3 achieved a 93.3% score on the 2025 AIME, a challenging mathematics competition released merely days before the model's test. This demonstrates exceptional zero-shot problem-solving capabilities without relying on memorized test sets.
+*   **"Think" Mode:** By employing high levels of test-time compute (e.g., cons@64), the model effectively searches through possible solution paths, self-correcting and refining its logic before presenting the final output.
+
+## Real-World Application & Who Should Care
+
+**🚀 THE PERFORMANCE MONSTERS (SOTA Seekers):**
+Researchers and engineers tackling complex STEM problems, advanced coding challenges, or multi-step logic puzzles should utilize Grok 3's "Think" mode. The model's ability to scale performance with increased inference compute makes it a prime candidate for tasks where accuracy is paramount and latency is a secondary concern.
+
+**💰 THE COST & LATENCY OPTIMIZERS (API Developers):**
+For developers focused on high-throughput applications, the full "Think" mode may introduce prohibitive latency and costs. However, smaller or faster variants of Grok 3 (if made available via API) could offer a balanced approach, allowing developers to route complex queries to the reasoning engine while handling standard requests with a more efficient model.
+
+**💻 THE EVERYDAY PROMPT ENGINEERS:**
+When interacting with Grok 3 on the web or mobile app, use "Think" mode for your hardest questions, like debugging complex code, planning detailed itineraries, or solving math problems. For simple factual queries or casual conversation, stick to the standard mode to receive instant responses.
+
+## Sources
+*   [xAI News: Grok 3 Beta](https://x.ai/news/grok-3)
+*   [Wikipedia: Grok (chatbot)](https://en.wikipedia.org/wiki/Grok_(chatbot))


### PR DESCRIPTION
This change introduces the frontier model Grok 3 to the wiki, detailing its massive test-time compute scaling (Think mode) and strong mathematical capabilities, along with insights on practical applications for different audience segments. It updates README.md with the index entry and check_links.sh script.

---
*PR created automatically by Jules for task [6705905537310457734](https://jules.google.com/task/6705905537310457734) started by @tryigit*