### PR TITLE
feat(model): add DeepSeek-V3.2 and Sparse Attention analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A smart knowledge base about artificial intelligence.
 *   [Qwen 2.5-VL: The Vision-Language Flagship](models/qwen-2-5-vl.md) - *A multimodal model for native dynamic resolution, long-video comprehension, and visual agent tasks.*
 *   [DeepSeek-R1: The Open-Source Reasoning Champion](models/deepseek-r1.md) - *The first open-weights model to rival o1 using Pure RL.*
 *   [DeepSeek-V3: The Open-Source Titan Behind R1](models/deepseek-v3.md) - *The 671B MoE base model for R1 with innovative MLA and DeepSeekMoE.*
+*   [DeepSeek-V3.2: The Sparse Attention Evolution](models/deepseek-v3-2.md) - *The 685B model that introduces DeepSeek Sparse Attention (DSA) for efficient long-context processing.*
 *   [OpenAI o3-mini: High-Speed Reasoning for the Masses](models/o3-mini.md) - *A fast, cost-efficient reasoning model tailored for STEM and coding tasks.*
 
 ## Frontier Research & Papers

--- a/check_links.sh
+++ b/check_links.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-files="concepts/rlhf.md models/grok-3.md README.md papers/areal.md papers/flash-attention-4.md concepts/group-relative-policy-optimization.md concepts/flash-attention.md"
+files="concepts/rlhf.md models/grok-3.md README.md papers/areal.md papers/flash-attention-4.md concepts/group-relative-policy-optimization.md concepts/flash-attention.md models/deepseek-v3-2.md models/deepseek-v3.md"
 for file in $files; do
   echo "Checking links in $file"
   # extract links that look like (relative/path.md)

--- a/models/deepseek-v3-2.md
+++ b/models/deepseek-v3-2.md
@@ -1,0 +1,47 @@
+# DeepSeek-V3.2: The Sparse Attention Evolution
+
+**TL;DR:**
+DeepSeek-V3.2 is an advancement over the original V3 model, primarily defined by the introduction of **DeepSeek Sparse Attention (DSA)**. It maintains the massive Mixture-of-Experts (MoE) backbone of its predecessor but drastically improves the efficiency of long-context inference. The series includes multiple variants, with the 685B parameter *Speciale* version achieving GPT-5 level reasoning in mathematical and algorithmic benchmarks.
+
+---
+
+## The Architecture: Evolving from MLA to DSA
+DeepSeek-V3.2 builds directly upon the foundation laid by [DeepSeek-V3](../models/deepseek-v3.md), keeping the same embedding and [RoPE](../concepts/rotary-position-embedding.md) positional encoding while making a critical upgrade to its attention mechanism.
+
+### 1. From MLA to DeepSeek Sparse Attention (DSA)
+In DeepSeek-V3, the [Multi-Head Latent Attention (MLA)](../concepts/multi-head-latent-attention.md) mechanism compressed the Key-Value (KV) cache into a latent vector to save memory. DSA builds on this by introducing a two-stage sparse attention process for even greater efficiency in long-context scenarios (up to 128K tokens):
+*   **Lightning Indexer:** A lightweight, low-precision (FP8) mechanism computes relevance scores between the current query token and all preceding tokens.
+*   **Fine-Grained Token Selection:** Instead of running full attention over the entire context, the model uses the indexer's scores to select only the top-$k$ most relevant key/value pairs. Standard attention is then only computed on this much smaller subset.
+This shifts the computational cost from the traditional $O(L^2)$ quadratic complexity of dense attention to a nearly linear $O(L \cdot k)$, where $k$ is much smaller than the sequence length $L$.
+
+### 2. DeepSeekMoE Backbone
+The model retains the DeepSeekMoE architecture, activating only around 37 billion parameters per token during inference to maintain high speed. It utilizes [Group Relative Policy Optimization (GRPO)](../concepts/group-relative-policy-optimization.md) for stable reinforcement learning.
+
+### 3. Model Variants
+DeepSeek-V3.2 was released in several flavors to target different use cases:
+*   **V3.2 (Base):** The daily driver balancing latency, cost, and strong reasoning capabilities.
+*   **V3.2-Exp (Experimental):** Explicitly designed to showcase DSA. Its training configuration was aligned with the older V3.1 to isolate and prove the efficiency gains of the new sparse attention mechanism.
+*   **V3.2-Speciale:** A reasoning-maximized, high-compute variant fine-tuned for complex, multi-step agentic workflows and competition-level math. It achieves gold-medal performance on IMO and IOI 2025 benchmarks.
+
+---
+
+## Real-World Application & Who Should Care
+
+### 🚀 For The Performance Monsters (SOTA Seekers)
+**Leverage Speciale for Complex Agentic Workflows.**
+The *Speciale* variant is designed for high-stakes reasoning. If you are building autonomous agents that require deep logical consistency, extensive tool use, and multi-step verification (such as automated software engineering or advanced data analysis), this variant offers reasoning proficiency on par with cutting-edge proprietary models like Gemini-3.0-Pro.
+
+### 💰 For The Cost & Latency Optimizers (API Developers)
+**Exploit DSA for Cheaper Long-Context Ingestion.**
+The introduction of DeepSeek Sparse Attention means you can now feed massive documents, extensive codebases, or long-running chat logs (up to 128K tokens) into the model at a fraction of the computational cost and latency. Early reports indicate up to a 50% reduction in cost for long-context API calls compared to dense attention models.
+
+### 💻 For The Everyday Prompt Engineers
+**Better RAG and Document Analysis.**
+When using web interfaces or basic API wrappers powered by V3.2, you will notice significantly faster response times when querying large uploaded documents. You can confidently upload larger datasets or longer conversational histories without experiencing the typical slowdowns associated with massive context windows.
+
+---
+
+## References
+*   [DeepSeek-V3.2: Pushing the Frontier of Open Large Language Models (arXiv)](https://arxiv.org/abs/2512.02556)
+*   [NVIDIA NIM: deepseek-v3.2 Model Card](https://build.nvidia.com/deepseek-ai/deepseek-v3_2/modelcard)
+*   [Milvus AI Quick Reference: Architecture Changes in V3.2](https://milvus.io/ai-quick-reference/what-architecture-changes-differentiate-deepseekv32-from-v31)

--- a/models/deepseek-v3.md
+++ b/models/deepseek-v3.md
@@ -9,7 +9,7 @@
 DeepSeek-V3 builds on the standard **[Transformer Architecture](../concepts/transformer-architecture.md)** but introduces several critical innovations to maximize efficiency and performance.
 
 ### 1. [Multi-Head Latent Attention (MLA)](../concepts/multi-head-latent-attention.md)
-Standard Transformers suffer from a large KV Cache, which consumes massive amounts of VRAM during generation. MLA compresses the Key-Value (KV) cache into a latent vector, reducing memory usage by up to 93% compared to standard MHA. This allows V3 to serve much longer contexts and larger batch sizes on the same hardware.
+Standard Transformers suffer from a large KV Cache, which consumes massive amounts of VRAM during generation. MLA compresses the Key-Value (KV) cache into a latent vector, reducing memory usage by up to 93% compared to standard MHA. This allows V3 to serve much longer contexts and larger batch sizes on the same hardware. *(Note: This mechanism has since been evolved into DeepSeek Sparse Attention (DSA) in the [DeepSeek-V3.2](../models/deepseek-v3-2.md) release).*
 
 ### 2. DeepSeekMoE (Fine-Grained Experts)
 Unlike traditional **[Mixture of Experts (MoE)](../concepts/mixture-of-experts.md)** (like Mixtral) which activate a few large experts, DeepSeek-V3 uses many small experts.


### PR DESCRIPTION
Added a detailed analysis of the newly released DeepSeek-V3.2 model, focusing on the introduction of DeepSeek Sparse Attention (DSA) and its variants. Cross-linked with the existing DeepSeek-V3 article, updated the main index in README.md, and ensured all links are valid.

---
*PR created automatically by Jules for task [16845246796830172392](https://jules.google.com/task/16845246796830172392) started by @tryigit*