### PR TITLE
feat: add PagedAttention concept and OpenClaw model

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 A smart knowledge base about artificial intelligence.
 
 ## Frontier Models
+*   [OpenClaw: The Viral Open-Source AI Agent](models/openclaw.md) - *An autonomous agent framework (formerly Moltbot) that executes local tasks via LLMs and messaging platforms.*
 *   [Grok 3: The Age of Reasoning Agents](models/grok-3.md) - *xAI's newest frontier model focusing on test-time compute and advanced mathematical reasoning.*
 *   [GLM-5: The 744B Frontier MoE Model](models/glm-5.md) - *Zhipu AI's flagship open-weights model featuring DeepSeek Sparse Attention and asynchronous RL for complex agentic tasks.*
 *   [Claude 3.7 Sonnet: The Hybrid Reasoning Engine](models/claude-3-7-sonnet.md) - *Anthropic's hybrid model that toggles between instant responses and extended thinking.*
@@ -18,6 +19,7 @@ A smart knowledge base about artificial intelligence.
 *   [Agent-as-a-Judge: Evaluate Agents with Agents](papers/agent-as-a-judge.md) - *Evaluating autonomous agents by using other agents to verify their process.*
 
 ## Core Concepts & Architecture
+*   [PagedAttention: Virtual Memory for LLMs](concepts/paged-attention.md) - *Eliminating KV cache fragmentation by borrowing operating system memory management concepts to maximize serving throughput.*
 *   [Reinforcement Learning from Human Feedback (RLHF)](concepts/rlhf.md) - *A technique to align an intelligent agent with human preferences by training a reward model to score responses and optimize the policy.*
 *   [Direct Preference Optimization (DPO)](concepts/direct-preference-optimization.md) - *A lightweight alternative to RLHF that turns the language model itself into a reward model via contrastive pairs.*
 *   [Group Relative Policy Optimization (GRPO): Efficient Reinforcement Learning](concepts/group-relative-policy-optimization.md) - *Streamlining RL by eliminating the value model and using group-based reward baselines.*

--- a/check_links.sh
+++ b/check_links.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-files="concepts/rlhf.md models/grok-3.md README.md papers/areal.md papers/flash-attention-4.md concepts/group-relative-policy-optimization.md concepts/flash-attention.md models/deepseek-v3-2.md models/deepseek-v3.md"
+files="concepts/rlhf.md models/grok-3.md README.md papers/areal.md papers/flash-attention-4.md concepts/group-relative-policy-optimization.md concepts/flash-attention.md models/deepseek-v3-2.md models/deepseek-v3.md concepts/paged-attention.md models/openclaw.md concepts/multi-head-latent-attention.md techniques/context-caching.md"
 for file in $files; do
   echo "Checking links in $file"
   # extract links that look like (relative/path.md)

--- a/concepts/multi-head-latent-attention.md
+++ b/concepts/multi-head-latent-attention.md
@@ -6,7 +6,7 @@ Multi-Head Latent Attention (MLA) is a highly efficient attention mechanism intr
 ---
 
 ## The Problem: The KV Cache Bottleneck
-In a standard **[Transformer Architecture](../concepts/transformer-architecture.md)**, the model predicts text one token at a time (autoregressive generation). To do this efficiently, the model caches the calculated "Keys" (K) and "Values" (V) for all previous tokens in the sequence. This is called the KV Cache.
+In a standard **[Transformer Architecture](../concepts/transformer-architecture.md)**, the model predicts text one token at a time (autoregressive generation). To do this efficiently, the model caches the calculated "Keys" (K) and "Values" (V) for all previous tokens in the sequence. This is called the **[KV Cache](../concepts/paged-attention.md)**.
 
 Without the KV Cache, the model would have to recalculate the entire history for every single new word. However, as the context window grows (e.g., to 128k or 1M tokens) or as batch sizes increase (serving multiple users), the KV Cache consumes a massive amount of VRAM (GPU Memory). Often, the KV Cache becomes larger than the model weights themselves, creating a severe memory bottleneck.
 

--- a/concepts/paged-attention.md
+++ b/concepts/paged-attention.md
@@ -1,0 +1,53 @@
+# PagedAttention: Virtual Memory for LLMs
+
+## TL;DR
+**PagedAttention** is a memory management algorithm introduced by researchers at UC Berkeley (and powering the popular vLLM inference engine). It solves the massive memory fragmentation problem in LLM serving by borrowing the concept of "virtual memory" from traditional operating systems. By partitioning the KV cache into small, non-contiguous, fixed-size blocks, PagedAttention nearly eliminates memory waste and allows for 2-3x higher serving throughput compared to naive caching strategies.
+
+---
+
+## The Problem: The Inefficient KV Cache
+
+During LLM text generation (inference), the model needs to remember the context of all previously generated tokens. It does this by storing their mathematical representations in the **KV Cache** (Key-Value Cache).
+
+In traditional serving systems, the KV cache for a single user's request was allocated as one giant, contiguous block of GPU memory. Because the system didn't know in advance exactly how many tokens the user would generate, it had to pre-allocate a maximum possible size (e.g., 2048 tokens).
+
+This contiguous allocation caused massive problems:
+*   **Internal Fragmentation:** The model might pre-allocate memory for 2048 tokens, but the user only generates 100. The remaining memory is locked up and wasted.
+*   **External Fragmentation:** As different requests with different memory sizes finish and free up space, holes appear in the GPU memory. A new request might not find a single contiguous block large enough to run, even if the total free memory is sufficient.
+*   **Memory Wall:** Prior systems wasted 60-80% of KV cache memory due to these fragmentation issues, severely bottlenecking how many concurrent users a GPU could serve.
+
+## The Solution: PagedAttention
+
+The creators of PagedAttention looked at how operating systems solved this exact problem decades ago for RAM using virtual memory and paging.
+
+Instead of storing the KV cache as one big chunk, PagedAttention breaks it down into small, fixed-size pages or "blocks" (e.g., each block storing exactly 16 tokens).
+
+1.  **Logical vs. Physical Memory:** PagedAttention separates the *logical* view of the KV cache (which looks like a continuous sequence of tokens to the model) from the *physical* view (where those blocks are actually stored in GPU memory).
+2.  **Dynamic Allocation:** When a request starts, it only gets the exact number of blocks needed for the prompt. As the model generates new tokens, it dynamically requests and fills new blocks one at a time.
+3.  **Non-Contiguous Storage:** These blocks do not need to sit next to each other in physical GPU memory. They can be scattered wherever there is space. A mapping table translates between the logical sequence and the physical blocks.
+
+### The Impact
+By eliminating the need for large contiguous allocations and dynamic resizing, PagedAttention results in near-optimal memory usage. Waste is reduced to under 4% (which only occurs in the very last, partially filled block). This efficiency directly translates into the ability to batch far more requests simultaneously, driving up GPU utilization and drastically lowering the cost of serving.
+
+---
+
+## Real-World Application & Who Should Care
+
+### 🚀 For The Performance Monsters (SOTA Seekers)
+If you are deploying large, high-capability models locally or on dedicated hardware, PagedAttention is what prevents out-of-memory (OOM) errors during heavy workloads.
+*   **Concurrent Agents:** When running multiple autonomous agents simultaneously, PagedAttention ensures that the context windows of those agents don't artificially block each other from running due to memory fragmentation.
+*   **Complex Decoding:** Advanced techniques like parallel sampling or beam search can share the exact same physical memory blocks for the initial prompt, diverging only when the generated sequences differ, massively saving memory.
+
+### 💰 For The Cost & Latency Optimizers (API Developers)
+PagedAttention is the underlying reason why API costs have plummeted across the industry.
+*   **Maximizing ROI:** Whether you are building your own infrastructure using vLLM or relying on providers like Together AI or Anyscale, PagedAttention is the engine that allows 2-3x more users to share the same GPU, cutting the operational cost per request by a similar margin.
+
+### 🧑‍💻 For The Everyday Prompt Engineers
+While you don't interact with PagedAttention directly, its existence changes how you can use models.
+*   **Long-Context Viability:** The reason you can drop a 100-page PDF into a model and not wait 5 minutes for a response is partially due to the efficient memory handling that systems utilizing PagedAttention provide. It makes massive context windows economically and computationally feasible for everyday use.
+
+---
+
+## References
+*   [Efficient Memory Management for Large Language Model Serving with PagedAttention](https://arxiv.org/abs/2309.06180) - The original paper introducing the concept.
+*   [vLLM Project](https://github.com/vllm-project/vllm) - The open-source serving engine powered by PagedAttention.

--- a/models/openclaw.md
+++ b/models/openclaw.md
@@ -1,0 +1,47 @@
+# OpenClaw: The Viral Open-Source AI Agent
+
+## TL;DR
+**OpenClaw** (formerly known as Clawdbot and Moltbot) is an open-source, autonomous artificial intelligence agent framework developed by Peter Steinberger. Initially released as a vibe-coding side project, it rapidly went viral for its unique ability to directly interface with messaging platforms (like WhatsApp, Telegram, and Discord) and execute powerful local system commands via third-party "skills." This massive adoption has sparked widespread security concerns due to its ability to operate locally with minimal sandboxing, giving it extensive control over personal data and system resources.
+
+---
+
+## What is OpenClaw?
+
+OpenClaw differentiates itself from standard conversational chatbots by acting as an "AI with hands." Instead of existing purely within a web browser, OpenClaw runs locally on a user's machine (or a dedicated server) and interacts directly with the operating system and external APIs.
+
+### Key Capabilities
+1.  **Messaging Integration:** OpenClaw was built to be native to messaging apps. Users interact with the agent through natural language in WhatsApp, Telegram, or Discord rather than a dedicated UI.
+2.  **Local Execution:** The framework has deep system access. It can automate tasks like reading and writing files, executing shell commands, managing calendars, and browsing the web.
+3.  **Extensibility (Skills):** OpenClaw features a plugin system called "skills." Developers can write custom tools that the agent can autonomously call upon to solve complex problems or integrate with new services.
+
+## The Viral Growth and the Security Nightmare
+
+The explosive growth of OpenClaw (prompting massive cloud deployments and even regional hardware shortages of Mac minis) was driven by its utility. However, this power comes with severe security implications that have triggered warnings from national cybersecurity agencies.
+
+### The Attack Surface
+*   **High Privileges:** Because OpenClaw is designed to be a local assistant, it often runs with the full user-level permissions of the host machine. If a malicious third-party "skill" is installed, or if the agent is compromised, it can read sensitive files, execute arbitrary code, or move laterally across networks.
+*   **Plaintext Secrets:** In early versions, API keys and session tokens for messaging platforms and other services were frequently stored without encryption.
+*   **Lack of Authentication:** Administrative interfaces or local endpoints often lack robust authentication by default, making them susceptible to unauthorized access on shared networks.
+*   **Agent Abuse:** Threat actors have begun deploying malicious skills disguised as useful utilities (like crypto tools) on the platform's skill repositories, treating OpenClaw as a new supply-chain attack vector.
+
+---
+
+## Real-World Application & Who Should Care
+
+### 🚀 For The Performance Monsters (SOTA Seekers)
+OpenClaw represents the wild west of autonomous agentic systems.
+*   **Unrestricted Automation:** If you want an agent that can genuinely manage your inbox, scrape the web, execute Python scripts, and text you the results on WhatsApp without vendor lock-in or cloud safety guardrails blocking your workflows, OpenClaw is the framework to build upon.
+
+### 💰 For The Cost & Latency Optimizers (API Developers)
+Running OpenClaw introduces significant operational challenges.
+*   **The Cost of Autonomy:** OpenClaw agents are notorious for consuming massive amounts of API credits as they autonomously loop, plan, and execute tasks. A misconfigured agent can silently drain millions of tokens overnight. You must implement strict spending limits and monitoring if you intend to host or integrate with this ecosystem.
+
+### 🧑‍💻 For The Everyday Prompt Engineers
+OpenClaw moves you from "prompting an interface" to "managing a digital employee."
+*   **Vibe Coding Reality:** OpenClaw proves that highly capable agents can be spun up quickly. However, you *must* run it in a sandboxed environment (like an isolated Docker container or a dedicated virtual machine) and never give it access to your primary email or sensitive files until the security architecture matures.
+
+---
+
+## References
+*   [OpenClaw Wikipedia](https://en.wikipedia.org/wiki/OpenClaw) - The history of the project's evolution from Clawdbot to Moltbot.
+*   [When the "AI With Hands" Becomes a Digital Minefield](https://medium.com/@scottbolen/openclaw-clawdbot-moltbot-when-the-ai-with-hands-becomes-a-digital-minefield-cti-deep-dive-720e9739320e) - A deep dive into the cybersecurity risks of the framework.

--- a/techniques/context-caching.md
+++ b/techniques/context-caching.md
@@ -1,7 +1,7 @@
 # Context Caching: The Cost-Cutting Superpower for Long-Context AI
 
 ## TL;DR
-**Context Caching** is a technique that allows developers to store (cache) the processed state (KV Cache) of a large prompt prefix—such as a system instruction, a long document, or a codebase—and reuse it across multiple API calls. Instead of paying to re-process the same 50,000 tokens for every user request, you only pay once to cache it, and then pay a heavily discounted rate (often 50-90% off) for subsequent hits.
+**Context Caching** is a technique that allows developers to store (cache) the processed state (**[KV Cache](../concepts/paged-attention.md)**) of a large prompt prefix—such as a system instruction, a long document, or a codebase—and reuse it across multiple API calls. Instead of paying to re-process the same 50,000 tokens for every user request, you only pay once to cache it, and then pay a heavily discounted rate (often 50-90% off) for subsequent hits.
 
 ---
 


### PR DESCRIPTION
I researched and drafted two new articles today, carefully maintaining the balance between foundational concepts and frontier developments.

1.  **Foundational Content (`concepts/paged-attention.md`)**: I wrote a deep dive into PagedAttention, the memory management algorithm powering vLLM. It explains how borrowing virtual memory concepts from operating systems drastically reduces KV cache fragmentation and increases serving throughput.
2.  **Frontier Content (`models/openclaw.md`)**: I documented OpenClaw (formerly Moltbot/Clawdbot), a highly capable and currently viral open-source AI agent framework. The article highlights its ability to interface directly with messaging apps and local systems, alongside a critical look at the resulting security implications.

In accordance with the rules, both articles feature a TL;DR, source links, and a detailed "Real-World Application & Who Should Care" section broken down for SOTA seekers, cost optimizers, and everyday prompt engineers. I successfully avoided using long em-dashes.

Finally, I updated the index in `README.md` and added internal cross-links for the "KV Cache" term in the existing `multi-head-latent-attention.md` and `context-caching.md` articles to build up the interconnected wiki. I also updated the `check_links.sh` test script to ensure all new cross-links are validated.

---
*PR created automatically by Jules for task [9434975102879135390](https://jules.google.com/task/9434975102879135390) started by @tryigit*