### PR TITLE
feat(model): add GPT-5.4 mini/nano and Xiaomi MiMo

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 A smart knowledge base about artificial intelligence.
 
 ## Frontier Models
+*   [GPT-5.4 mini and nano: High-Volume Efficiency](models/gpt-5-4-mini-and-nano.md) - *OpenAI's latest highly efficient models optimized for speed, cost, and high-volume workloads.*
+*   [Xiaomi MiMo: The "Hunter Alpha" Stealth Model](models/hunter-alpha-mimo.md) - *Xiaomi's stealth model that surfaced anonymously and sparked widespread speculation.*
 *   [Mistral Small 4: The Unified MoE Model](models/mistral-small-4.md) - *Mistral AI's 119B hybrid MoE model combining reasoning, multimodal, and agentic capabilities.*
 *   [Grok 3: The Age of Reasoning Agents](models/grok-3.md) - *xAI's newest frontier model focusing on test-time compute and advanced mathematical reasoning.*
 *   [GLM-5: The 744B Frontier MoE Model](models/glm-5.md) - *Zhipu AI's flagship open-weights model featuring DeepSeek Sparse Attention and asynchronous RL for complex agentic tasks.*

--- a/check_links.sh
+++ b/check_links.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-files="concepts/state-space-models.md models/mistral-small-4.md models/openmanus.md concepts/causal-vs-masked-language-models.md concepts/paged-attention.md concepts/grouped-query-attention.md concepts/rlhf.md models/grok-3.md README.md papers/areal.md papers/flash-attention-4.md concepts/group-relative-policy-optimization.md concepts/flash-attention.md models/deepseek-v3-2.md models/deepseek-v3.md"
+files="models/gpt-5-4-mini-and-nano.md models/hunter-alpha-mimo.md concepts/state-space-models.md models/mistral-small-4.md models/openmanus.md concepts/causal-vs-masked-language-models.md concepts/paged-attention.md concepts/grouped-query-attention.md concepts/rlhf.md models/grok-3.md README.md papers/areal.md papers/flash-attention-4.md concepts/group-relative-policy-optimization.md concepts/flash-attention.md models/deepseek-v3-2.md models/deepseek-v3.md"
 for file in $files; do
   echo "Checking links in $file"
   # extract links that look like (relative/path.md)

--- a/models/gpt-5-4-mini-and-nano.md
+++ b/models/gpt-5-4-mini-and-nano.md
@@ -1,0 +1,31 @@
+# OpenAI GPT-5.4 mini and nano: High-Volume Efficiency
+
+## TL;DR
+Released in March 2026, **GPT-5.4 mini** and **GPT-5.4 nano** are OpenAI's latest highly efficient models optimized for speed, cost, and high-volume workloads. They bring the core strengths of the GPT-5.4 family into smaller packages, making them ideal for responsive coding assistants, autonomous subagents, and real-time multimodal tasks. They are designed for scenarios where latency and cost are just as critical as raw intelligence.
+
+## Key Specs & Features
+
+*   **GPT-5.4 mini:** A significant upgrade over GPT-5 mini. It offers improved performance across coding, reasoning, multimodal understanding, and tool use, while running more than twice as fast. It approaches the performance of the larger GPT-5.4 on benchmarks like SWE-Bench Pro and OSWorld-Verified.
+*   **GPT-5.4 nano:** The smallest and cheapest model in the GPT-5.4 lineup. It is optimized for tasks where maximum speed and minimum cost are the primary goals, such as classification, data extraction, ranking, and powering simple coding subagents.
+*   **Focus on Latency:** Both models are built for real-time applications where responsiveness shapes the user experience, including computer-using systems that capture and interpret screenshots on the fly.
+*   **Targeted Workloads:** They are explicitly not designed to replace large reasoning models, but rather to serve as the fast, reliable engine for high-volume API calls and background tasks.
+
+## Real-World Application & Who Should Care
+
+### 🚀 For The Performance Monsters (SOTA Seekers)
+While these models prioritize efficiency over maximum capability, they are highly valuable for complex architectures.
+*   **Agentic Workflows:** You can use GPT-5.4 mini to power fast, parallel subagents that handle data gathering and preliminary analysis, feeding the results into a larger reasoning model like [OpenAI o3-mini](o3-mini.md) for the final, complex decision-making step.
+*   **High-Speed Processing:** For tasks requiring rapid iteration, the 2x speedup of GPT-5.4 mini allows for much faster experimentation and pipeline execution.
+
+### 💰 For The Cost & Latency Optimizers (API Developers)
+These models are built entirely for this demographic.
+*   **Massive Cost Reduction:** GPT-5.4 nano is designed to be the cheapest option for bulk operations like parsing unstructured text, basic classification, and sentiment analysis across millions of records.
+*   **Real-Time Responsiveness:** The low latency of GPT-5.4 mini makes it the optimal choice for user-facing applications like real-time chat, autocomplete features, and responsive coding assistants where delays frustrate users.
+
+### 💻 For The Everyday Prompt Engineers
+*   **Snappy Interactions:** When using these models in a web interface, expect near-instantaneous responses for everyday tasks like drafting emails, summarizing short articles, or basic coding questions.
+*   **Efficient Tool Use:** They are highly capable of using tools and navigating web interfaces quickly, making them excellent assistants for gathering information without the wait times associated with larger models.
+
+## References
+*   [Introducing GPT-5.4 mini and nano - OpenAI](https://openai.com/index/introducing-gpt-5-4-mini-and-nano/)
+*   [OpenAI launches GPT-5.4 mini and nano AI models](https://www.edtechinnovationhub.com/news/openai-releases-gpt-54-mini-and-nano-to-target-high-volume-ai-workloads)

--- a/models/hunter-alpha-mimo.md
+++ b/models/hunter-alpha-mimo.md
@@ -1,0 +1,29 @@
+# Xiaomi MiMo: The "Hunter Alpha" Stealth Model
+
+## TL;DR
+In March 2026, a mysterious and highly capable AI model surfaced anonymously on the OpenRouter developer platform under the name **"Hunter Alpha"** (or "Hunter/Healer Alpha"), initially billed as a "stealth model". It fueled widespread speculation that it might be an unannounced, next-generation model from Chinese startup DeepSeek (potentially "DeepSeek V4"). However, it was later officially revealed to be an early test version of a model called **MiMo**, developed by the Chinese smartphone and electric vehicle giant **Xiaomi**.
+
+## Key Specs & Features
+
+*   **The Stealth Release:** The model appeared without developer attribution on March 11, creating significant buzz in the AI community.
+*   **The DeepSeek Speculation:** Given its capabilities, Chinese language focus, and training data cutoff matching other DeepSeek models, developers initially suspected it was a secret test of DeepSeek's highly anticipated next-generation system. This speculation followed the massive global impact of DeepSeek's earlier low-cost releases like [DeepSeek-V3](deepseek-v3.md).
+*   **The Xiaomi Reveal:** The true identity was confirmed when the OpenRouter information was updated, revealing the "Hunter Alpha" stealth model was actually **MiMo** from Xiaomi.
+*   **Legal Compliance:** The model reportedly states its identity as a Chinese AI model that strictly complies with the laws and regulations of the People's Republic of China.
+
+## Real-World Application & Who Should Care
+
+### 🚀 For The Performance Monsters (SOTA Seekers)
+The emergence of powerful models from unexpected players like Xiaomi indicates a rapidly broadening competitive landscape in frontier AI.
+*   **New Architectures to Test:** While specific technical details of MiMo are currently undisclosed, its initial reception and the DeepSeek speculation suggest it possesses significant capabilities worth benchmarking for complex reasoning or agentic tasks once officially released.
+
+### 💰 For The Cost & Latency Optimizers (API Developers)
+The entry of a major hardware manufacturer like Xiaomi into the frontier AI space could lead to interesting deployment strategies.
+*   **Potential Hardware Integration:** If Xiaomi optimizes MiMo for its own massive ecosystem of smartphones and EVs, it could lead to highly efficient, localized, or edge-capable models, potentially disrupting current API pricing structures in the future.
+
+### 💻 For The Everyday Prompt Engineers
+*   **More Options, Better Interfaces:** The intense competition among Chinese AI giants (like DeepSeek, Alibaba, and now Xiaomi) drives rapid innovation. Everyday users can expect these models to eventually power more capable and accessible consumer applications, particularly in mobile and smart home ecosystems.
+
+## References
+*   [Mystery AI model suspected to be DeepSeek V4 is revealed to be from Xiaomi](https://www.japantimes.co.jp/business/2026/03/19/tech/mystery-ai-model-china-buzz/)
+*   [Openrouter stealth model Hunter/Healer Alpha has been officially confirmed as MiMo](https://www.reddit.com/r/LocalLLaMA/comments/1rwm542/openrouter_stealth_model_hunterhealer_alpha_has/)
+*   [What is Hunter Alpha? (Reddit)](https://www.reddit.com/r/LocalLLaMA/comments/1rr5zfo/what_is_hunter_alpha/)


### PR DESCRIPTION
Added two new articles for newly emerged frontier models, fulfilling the daily execution workflow:
1. `models/gpt-5-4-mini-and-nano.md` covering OpenAI's high-efficiency models.
2. `models/hunter-alpha-mimo.md` covering Xiaomi's recent stealth release "Hunter Alpha" (MiMo).

Both files follow the stringent formatting rules, including TL;DRs, the mandatory "Real-World Application" sections tailored to the three required audience personas, and no long em-dashes.
Existing files were successfully cross-linked natively, and the README index + internal link check script have been updated and tested successfully.

---
*PR created automatically by Jules for task [18327623750759912580](https://jules.google.com/task/18327623750759912580) started by @tryigit*