### PR TITLE
feat(model): add analysis of Anthropic's Claude Opus 4.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 A smart knowledge base about artificial intelligence.
 
 ## Frontier Models
+*   [Claude Opus 4.6: The Long-Horizon Reasoning Engine](models/claude-opus-4-6.md) - *Anthropic's newly released model with a 1M token context window, engineered for long-horizon reasoning and autonomous agentic work.*
 *   [GPT-5.4 mini and nano: High-Volume Efficiency](models/gpt-5-4-mini-and-nano.md) - *OpenAI's latest highly efficient models optimized for speed, cost, and high-volume workloads.*
 *   [Xiaomi MiMo: The "Hunter Alpha" Stealth Model](models/hunter-alpha-mimo.md) - *Xiaomi's stealth model that surfaced anonymously and sparked widespread speculation.*
 *   [Mistral Small 4: The Unified MoE Model](models/mistral-small-4.md) - *Mistral AI's 119B hybrid MoE model combining reasoning, multimodal, and agentic capabilities.*

--- a/check_links.sh
+++ b/check_links.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-files="models/gpt-5-4-mini-and-nano.md models/hunter-alpha-mimo.md concepts/state-space-models.md models/mistral-small-4.md models/openmanus.md concepts/causal-vs-masked-language-models.md concepts/paged-attention.md concepts/grouped-query-attention.md concepts/rlhf.md models/grok-3.md README.md papers/areal.md papers/flash-attention-4.md concepts/group-relative-policy-optimization.md concepts/flash-attention.md models/deepseek-v3-2.md models/deepseek-v3.md"
+files="models/claude-opus-4-6.md models/gpt-5-4-mini-and-nano.md models/hunter-alpha-mimo.md concepts/state-space-models.md models/mistral-small-4.md models/openmanus.md concepts/causal-vs-masked-language-models.md concepts/paged-attention.md concepts/grouped-query-attention.md concepts/rlhf.md models/grok-3.md README.md papers/areal.md papers/flash-attention-4.md concepts/group-relative-policy-optimization.md concepts/flash-attention.md models/deepseek-v3-2.md models/deepseek-v3.md"
 for file in $files; do
   echo "Checking links in $file"
   # extract links that look like (relative/path.md)

--- a/models/claude-opus-4-6.md
+++ b/models/claude-opus-4-6.md
@@ -1,0 +1,49 @@
+# Claude Opus 4.6: The Long-Horizon Reasoning Engine
+
+## TL;DR
+Anthropic's newly released Claude Opus 4.6 is their most capable model yet, specifically engineered for long-horizon reasoning and autonomous agentic work. It features a massive 1M token context window (in beta) and excels at maintaining coherence, intent, and intermediate decision states across extended, deeply nested sessions. Unlike previous iterations that required frequent guidance, Opus 4.6 demonstrates strong independent initiative, identifying sub-tasks and self-correcting over hours of execution.
+
+---
+
+## Key Advancements
+
+### 1. Extended Temporal Depth and Coherence
+The defining feature of Opus 4.6 is not merely a raw intelligence bump, but a dramatic increase in "temporal depth." While earlier models like Opus 4.5 excelled at reasoning within bounded tasks, they often exhibited degradation in deeply nested or extended workflows. Opus 4.6 can execute complex plans that unfold over hours, holding context and intermediate decisions without losing coherence. This makes it ideal for autonomous agent frameworks where continuous context retention is critical.
+
+### 2. Autonomous Agentic Capabilities
+Opus 4.6 significantly reduces the need for human-in-the-loop steering during complex tasks. It independently:
+*   Identifies necessary sub-tasks.
+*   Revisits and evaluates its own reasoning before committing to decisions.
+*   Catches and corrects its own mistakes during review phases.
+This capability relies heavily on advanced [Inference-Time Compute](../concepts/inference-time-compute.md) to explore and verify multiple reasoning paths internally.
+
+### 3. The 1 Million Token Context Window
+Currently in beta, the 1M token context window allows Opus 4.6 to ingest entire codebases, massive datasets, or extensive documentation in a single prompt. This is crucial for tasks like enterprise-scale code refactoring, comprehensive legal research, and complex financial modeling where complete context is necessary for accurate synthesis.
+
+### 4. Benchmark Performance (GDPval-AA)
+On the GDPval-AA benchmark, designed to evaluate economically valuable knowledge work rather than just abstract reasoning, Opus 4.6 showed a roughly 190 Elo point improvement over Opus 4.5. Anthropic reports it outperforms the nearest competing frontier model, OpenAI's GPT-5.2, by approximately 144 Elo points in areas like finance, legal reasoning, and research synthesis.
+
+---
+
+## Real-World Application & Who Should Care
+
+### 🚀 For The Performance Monsters (SOTA Seekers)
+Opus 4.6 is the current gold standard for complex, unguided workflows.
+*   **Autonomous Engineering:** Use it as the core engine for advanced AI agents capable of entire application lifecycle management, from architecture design to multi-file implementation and testing, without needing hand-holding.
+*   **Deep Research:** Feed it massive, disparate datasets and let it synthesize high-level strategic insights over extended sessions.
+
+### 💰 For The Cost & Latency Optimizers (API Developers)
+This model is heavily optimized for capability, not cost.
+*   **Strategic Deployment:** Opus 4.6 will be expensive and slower than smaller models. Reserve it strictly for the most complex, high-value orchestration tasks (the "brain") while delegating simpler, high-volume sub-tasks to faster, cheaper models like Haiku or Sonnet.
+*   **Context Management:** Even with a 1M token window, sending that much context per request is costly. Utilize robust context caching strategies where applicable.
+
+### 💻 For The Everyday Prompt Engineers
+Your interaction paradigm changes with this model.
+*   **Set and Forget:** Instead of micromanaging the model with step-by-step instructions for every minor task, focus on writing robust, high-level goal definitions and constraints. Let the model handle the intermediate planning and execution.
+*   **"Show Your Work" Prompting:** Because the model will run for longer periods autonomously, prompt it to periodically output status updates or its current reasoning state so you can monitor its progress without interrupting it.
+
+---
+
+## References
+*   [Claude Opus 4.6 - AI Model Catalog | Microsoft Foundry Models](https://ai.azure.com/catalog/models/claude-opus-4-6)
+*   [Claude Opus 4.6: Features, Capabilities, and Model Comparison - MagicShot.ai](https://magicshot.ai/news/claude-opus-4-6-guide/)


### PR DESCRIPTION
Added a new article `models/claude-opus-4-6.md` covering Anthropic's newly released Claude Opus 4.6 model. The content includes a TL;DR, key advancements (1M token context, agentic work), practical applications for three target audiences, and references. Linked this new article in `README.md` under the "Frontier Models" section and added it to the `check_links.sh` verification script.

---
*PR created automatically by Jules for task [5027285521784865221](https://jules.google.com/task/5027285521784865221) started by @tryigit*