### PR TITLE
feat(concept): add StreamingLLM and Attention Sinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ A smart knowledge base about artificial intelligence.
 *   [Agent-as-a-Judge: Evaluate Agents with Agents](papers/agent-as-a-judge.md) - *Evaluating autonomous agents by using other agents to verify their process.*
 
 ## Core Concepts & Architecture
+*   [StreamingLLM & Attention Sinks: Efficient Streaming Language Models](concepts/streaming-llm.md) - *Generalizing LLMs trained with finite context windows to infinite sequences without fine-tuning.*
 *   [Continuous Batching: Iteration-Level Scheduling](concepts/continuous-batching.md) - *Maximizing GPU utilization by dynamically slotting in new requests as others finish.*
 *   [State Space Models (SSM) & Mamba: The Linear-Time Architecture](concepts/state-space-models.md) - *An alternative to Transformers that solves the quadratic attention bottleneck via selective state spaces.*
 *   [Causal vs. Masked Language Models](concepts/causal-vs-masked-language-models.md) - *The architectural divide between generative decoder-only models (like GPT) and bidirectional encoder-only models (like BERT).*

--- a/check_links.sh
+++ b/check_links.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-files="models/gemini-3-1-pro.md models/claude-opus-4-6.md models/gpt-5-4-mini-and-nano.md models/hunter-alpha-mimo.md concepts/state-space-models.md models/mistral-small-4.md models/openmanus.md concepts/causal-vs-masked-language-models.md concepts/paged-attention.md concepts/grouped-query-attention.md concepts/rlhf.md models/grok-3.md README.md papers/areal.md papers/flash-attention-4.md concepts/group-relative-policy-optimization.md concepts/flash-attention.md models/deepseek-v3-2.md models/deepseek-v3.md concepts/continuous-batching.md news/dynatomics.md"
+files="concepts/streaming-llm.md models/gemini-3-1-pro.md models/claude-opus-4-6.md models/gpt-5-4-mini-and-nano.md models/hunter-alpha-mimo.md concepts/state-space-models.md models/mistral-small-4.md models/openmanus.md concepts/causal-vs-masked-language-models.md concepts/paged-attention.md concepts/grouped-query-attention.md concepts/rlhf.md models/grok-3.md README.md papers/areal.md papers/flash-attention-4.md concepts/group-relative-policy-optimization.md concepts/flash-attention.md models/deepseek-v3-2.md models/deepseek-v3.md concepts/continuous-batching.md news/dynatomics.md"
 for file in $files; do
   echo "Checking links in $file"
   # extract links that look like (relative/path.md)

--- a/concepts/paged-attention.md
+++ b/concepts/paged-attention.md
@@ -9,6 +9,8 @@
 ---
 
 ## The Problem: KV Cache Fragmentation
+*See also: **[StreamingLLM & Attention Sinks](../concepts/streaming-llm.md)** for a deep dive into finite context windows and KV cache eviction.*
+
 
 During autoregressive generation in a standard **[Transformer Architecture](transformer-architecture.md)**, the model must store the computed Keys and Values of all previous tokens to avoid recalculating them for every new word. This storage is called the **KV Cache**.
 

--- a/concepts/streaming-llm.md
+++ b/concepts/streaming-llm.md
@@ -1,0 +1,54 @@
+# StreamingLLM & Attention Sinks: Efficient Streaming Language Models
+
+## TL;DR
+StreamingLLM is an efficient framework developed by researchers from MIT, Meta AI, CMU, and NVIDIA that enables Large Language Models (LLMs) trained with a finite-length attention window to generalize to infinite sequence lengths without any fine-tuning. The core discovery enabling this is the concept of **"Attention Sinks"**, where models naturally assign excessively high attention scores to the initial tokens of a prompt, regardless of their semantic meaning. By keeping these initial tokens in the KV cache permanently, models can process millions of tokens stably.
+
+---
+
+## The Problem: Finite Context Windows and KV Cache Eviction
+Standard [Transformer Architecture](../concepts/transformer-architecture.md) models are trained with finite context windows (e.g., 4K or 8K tokens). When processing text longer than this training length, models face two primary issues:
+1.  **Memory Constraints:** The Key-Value (KV) cache grows linearly with sequence length. Storing millions of tokens in the KV cache is computationally infeasible due to memory limits, prompting the need for eviction strategies like Sliding Window Attention.
+2.  **Performance Degradation:** If the context exceeds the window and older tokens are evicted from the KV cache to save memory, the model's output quality typically collapses completely (perplexity spikes).
+
+Prior to StreamingLLM, attempts to solve this involved re-computing the entire context window for every new token, which is prohibitively slow, or fine-tuning the model for length extrapolation, which is expensive and complex.
+
+## The Solution: Attention Sinks
+The researchers made a surprising empirical observation: **Autoregressive LLMs naturally learn to use the very first few tokens in a sequence as a "sink" for unnecessary attention weight.**
+
+In the softmax operation of the attention mechanism, all attention weights must sum to 1.0. Even if a current token doesn't find any prior tokens particularly relevant to its current context, it still has to allocate attention somewhere. The models learn to dump this "excess" attention onto the initial tokens (the attention sinks).
+
+If these initial tokens are evicted from the KV cache (as in naive Sliding Window approaches), the attention mechanism breaks down, causing the model to fail.
+
+### How StreamingLLM Works
+StreamingLLM capitalizes on this discovery with a simple, elegant algorithm that requires **zero fine-tuning**:
+*   It maintains a fixed-size KV cache.
+*   It permanently keeps the **Attention Sinks** (typically just the first 4 initial tokens of the prompt) in the cache.
+*   It keeps a **Sliding Window** of the most recent tokens (e.g., the last 1024 tokens).
+*   All intermediate tokens are evicted.
+
+By simply retaining those first 4 "sink" tokens alongside the recent context, models like Llama-2, MPT, and Falcon can stream millions of tokens stably, maintaining low perplexity and high generation quality indefinitely.
+
+---
+
+## Real-World Application & Who Should Care
+
+### 🚀 For The Performance Monsters (SOTA Seekers)
+StreamingLLM unlocks true continuous operation for AI agents.
+*   **Infinite Agents:** If you are building autonomous agents that need to run continuously for days or weeks (e.g., monitoring a constant stream of logs or a long-running chat session), StreamingLLM allows the model to stay "awake" indefinitely without crashing due to context limits or requiring periodic resets.
+*   **Zero-Shot Deployment:** Because it requires no fine-tuning, you can apply this technique immediately to existing pre-trained open-source models to extend their operational lifespan.
+
+### 💰 For The Cost & Latency Optimizers (API Developers)
+This is a game-changer for reducing serving costs.
+*   **Constant Memory Footprint:** Instead of a KV cache that grows linearly until it OOMs (Out Of Memory), your KV cache stays at a fixed, predictable size. This drastically simplifies deployment and increases the batch size you can support on a single GPU.
+*   **Massive Speedups:** Compared to approaches that recompute the context window, StreamingLLM offers massive latency improvements (up to 22x speedup) because it only processes the new token against a small, fixed-size cache.
+
+### 🧑‍💻 For The Everyday Prompt Engineers
+While this is primarily an infrastructure-level optimization, the concept of Attention Sinks provides insight into how models behave.
+*   **System Prompts:** It reinforces the importance of the very beginning of your prompt. While the model might use the first few tokens purely as an attention sink, the tokens immediately following them (often your system instructions) remain foundational.
+*   **Long-Running Chats:** When using platforms that implement these streaming optimizations, you can expect your long chat sessions to remain coherent without sudden drops in quality, even if earlier parts of the conversation are "forgotten" (evicted from the sliding window).
+
+---
+
+## References
+*   [Efficient Streaming Language Models with Attention Sinks (Xiao et al., 2023)](https://arxiv.org/abs/2309.17453)
+*   [StreamingLLM GitHub Repository](https://github.com/mit-han-lab/streaming-llm)


### PR DESCRIPTION
Drafted a foundational article on the concept of StreamingLLM and Attention Sinks. This technique ensures LLMs trained on finite context windows can generalize to infinite sequence lengths without fine tuning by caching the initial tokens (Attention Sinks). Interlinked the new article with the existing PagedAttention concept, included real world applications, updated the check_links.sh to include the new path, updated the README.md index, and verified that no links were broken via a testing step.

---
*PR created automatically by Jules for task [14835803712045041819](https://jules.google.com/task/14835803712045041819) started by @tryigit*