### PR TITLE
feat(model): add MiniMax M2.7 and Xiaomi MiMo-V2-Pro analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 A smart knowledge base about artificial intelligence.
 
 ## Frontier Models
+*   [MiniMax M2.7: SOTA Open Model](models/minimax-m2-7.md) - *MiniMax's SOTA open model matching GLM-5 at 1/3 the cost.*
+*   [Xiaomi MiMo-V2-Pro: The API-Only Reasoning Engine](models/xiaomi-mimo-v2-pro.md) - *Xiaomi's API-only reasoning entrant with a 1M context window.*
 *   [Gemini 3.1 Pro: The Expanded Context Engine](models/gemini-3-1-pro.md) - *Google's frontier reasoning model with a 1M token context window, natively multimodal.*
 *   [Claude Opus 4.6: The Long-Horizon Reasoning Engine](models/claude-opus-4-6.md) - *Anthropic's newly released model with a 1M token context window, engineered for long-horizon reasoning and autonomous agentic work.*
 *   [GPT-5.4 mini and nano: High-Volume Efficiency](models/gpt-5-4-mini-and-nano.md) - *OpenAI's latest highly efficient models optimized for speed, cost, and high-volume workloads.*

--- a/check_links.sh
+++ b/check_links.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-files="concepts/streaming-llm.md models/gemini-3-1-pro.md models/claude-opus-4-6.md models/gpt-5-4-mini-and-nano.md models/hunter-alpha-mimo.md concepts/state-space-models.md models/mistral-small-4.md models/openmanus.md concepts/causal-vs-masked-language-models.md concepts/paged-attention.md concepts/grouped-query-attention.md concepts/rlhf.md models/grok-3.md README.md papers/areal.md papers/flash-attention-4.md concepts/group-relative-policy-optimization.md concepts/flash-attention.md models/deepseek-v3-2.md models/deepseek-v3.md concepts/continuous-batching.md news/dynatomics.md"
+files="concepts/streaming-llm.md models/gemini-3-1-pro.md models/claude-opus-4-6.md models/gpt-5-4-mini-and-nano.md models/hunter-alpha-mimo.md concepts/state-space-models.md models/mistral-small-4.md models/openmanus.md concepts/causal-vs-masked-language-models.md concepts/paged-attention.md concepts/grouped-query-attention.md concepts/rlhf.md models/grok-3.md README.md papers/areal.md papers/flash-attention-4.md concepts/group-relative-policy-optimization.md concepts/flash-attention.md models/deepseek-v3-2.md models/deepseek-v3.md concepts/continuous-batching.md news/dynatomics.md models/minimax-m2-7.md models/xiaomi-mimo-v2-pro.md"
 for file in $files; do
   echo "Checking links in $file"
   # extract links that look like (relative/path.md)

--- a/models/glm-5.md
+++ b/models/glm-5.md
@@ -4,7 +4,7 @@
 **Key Concepts:** Mixture of Experts (MoE), DeepSeek Sparse Attention (DSA), Asynchronous RL
 
 ## TL;DR
-GLM-5 is a recently released frontier large language model by Zhipu AI, targeting complex systems engineering and long-horizon agentic tasks. It is a 744B-parameter [Mixture of Experts (MoE)](../concepts/mixture-of-experts.md) model with 40B active parameters per token. Building on its predecessor, GLM-5 introduces DeepSeek Sparse Attention (DSA) for efficient long-context handling (up to 200K tokens) and employs a novel [asynchronous reinforcement learning](../papers/areal.md) infrastructure called "slime" to maximize post-training iteration efficiency. It currently stands as one of the most capable open-weight models available.
+GLM-5 is a recently released frontier large language model by Zhipu AI (now matched in performance by efficient alternatives like [MiniMax M2.7](minimax-m2-7.md)), targeting complex systems engineering and long-horizon agentic tasks. It is a 744B-parameter [Mixture of Experts (MoE)](../concepts/mixture-of-experts.md) model with 40B active parameters per token. Building on its predecessor, GLM-5 introduces DeepSeek Sparse Attention (DSA) for efficient long-context handling (up to 200K tokens) and employs a novel [asynchronous reinforcement learning](../papers/areal.md) infrastructure called "slime" to maximize post-training iteration efficiency. It currently stands as one of the most capable open-weight models available.
 
 ---
 

--- a/models/hunter-alpha-mimo.md
+++ b/models/hunter-alpha-mimo.md
@@ -1,7 +1,7 @@
 # Xiaomi MiMo: The "Hunter Alpha" Stealth Model
 
 ## TL;DR
-In March 2026, a mysterious and highly capable AI model surfaced anonymously on the OpenRouter developer platform under the name **"Hunter Alpha"** (or "Hunter/Healer Alpha"), initially billed as a "stealth model". It fueled widespread speculation that it might be an unannounced, next-generation model from Chinese startup DeepSeek (potentially "DeepSeek V4"). However, it was later officially revealed to be an early test version of a model called **MiMo**, developed by the Chinese smartphone and electric vehicle giant **Xiaomi**.
+In March 2026, a mysterious and highly capable AI model surfaced anonymously on the OpenRouter developer platform under the name **"Hunter Alpha"** (or "Hunter/Healer Alpha"), initially billed as a "stealth model". It fueled widespread speculation that it might be an unannounced, next-generation model from Chinese startup DeepSeek (potentially "DeepSeek V4"). However, it was later officially revealed to be an early test version of a model called **MiMo**, developed by the Chinese smartphone and electric vehicle giant **Xiaomi** (which later released the API-only reasoning model [MiMo-V2-Pro](xiaomi-mimo-v2-pro.md)).
 
 ## Key Specs & Features
 

--- a/models/minimax-m2-7.md
+++ b/models/minimax-m2-7.md
@@ -1,0 +1,41 @@
+# MiniMax M2.7: SOTA Open Model
+
+**Category:** Frontier Models
+**Key Concepts:** Self-Evolving Models, Multi-Agent Collaboration
+
+## TL;DR
+MiniMax M2.7 is a frontier open-weight model released by Chinese AI startup MiniMax. It stands out by matching the performance of [GLM-5](glm-5.md) on reasoning benchmarks while costing only one-third as much ($0.30 in / $1.20 out per 1M tokens vs GLM-5). Notably, the MiniMax team describes M2.7 as possessing "Early Echoes of Self-Evolution," meaning the model deeply participated in its own development loop by handling 30% to 50% of the workflow itself. It boasts a 205K context window and features robust capabilities for multi-agent collaboration ("Agent Teams").
+
+---
+
+## Architectural Breakthroughs & Features
+
+MiniMax M2.7 represents an advancement not just in model capability, but in the *methodology* of model training itself:
+
+*   **Self-Evolution Capabilities:** The most striking feature of M2.7 is its role in its own creation. The internal harness was used to recursively improve the model: it collected feedback, built evaluation sets, and iterated on skills, memory, and architecture. MiniMax claims M2.7 is capable of handling 30% to 50% of the typical engineering workflow required to build and refine it.
+*   **High Efficiency & Cost-Effectiveness:** According to the Artificial Analysis Intelligence Index, M2.7 matches GLM-5 with a score of 50. However, it achieves this at a drastically reduced cost, making it highly competitive on the cost/performance frontier.
+*   **Multi-Agent Collaboration:** The model introduces "Agent Teams," explicitly designed for scenarios where multiple AI agents must collaborate to solve complex problems.
+*   **Context Window:** M2.7 features a 205K token context window, allowing it to process substantial amounts of information, such as large codebases or extensive financial documents.
+*   **Finance Use Cases:** Following the trend of models like Claude and GPT, MiniMax has specifically applied M2.7 to finance-specific use cases, indicating strong performance in structured data analysis and reasoning.
+
+---
+
+## Real-World Application & Who Should Care
+
+### 🚀 The Performance Monsters (SOTA Seekers)
+**Why you care:** The concept of "self-evolution" is a holy grail in AI research. M2.7 provides a tangible example of a model that accelerates its own development loop.
+**Action:** Researchers should evaluate M2.7's performance on recursive tasks and self-correction benchmarks to understand how close we are to truly autonomous AI development.
+
+### 💰 The Cost & Latency Optimizers (API Developers)
+**Why you care:** M2.7 hits the sweet spot of SOTA reasoning capabilities at a fraction of the cost of its peers (like GLM-5).
+**Action:** If your application requires high intelligence but your unit economics are strained by expensive proprietary APIs, M2.7 is a prime candidate for deployment, especially for heavy agentic workflows.
+
+### 💻 The Everyday Prompt Engineers
+**Why you care:** The model is optimized for multi-agent collaboration and comes with an open-source demo called OpenRoom for entertainment use cases.
+**Action:** Utilize M2.7 for building complex, multi-step agent workflows where different "personas" or sub-agents need to interact reliably.
+
+---
+
+## References
+*   [Latent Space: AINews - MiniMax 2.7: GLM-5 at 1/3 cost SOTA Open Model](https://www.latent.space/p/ainews-minimax-27-glm-5-at-13-cost)
+*   [Price Per Token: New AI Model Releases](https://pricepertoken.com/news/model-releases)

--- a/models/xiaomi-mimo-v2-pro.md
+++ b/models/xiaomi-mimo-v2-pro.md
@@ -1,0 +1,40 @@
+# Xiaomi MiMo-V2-Pro: The API-Only Reasoning Engine
+
+**Category:** Frontier Models
+**Key Concepts:** API-Only Models, High Token Efficiency
+
+## TL;DR
+Xiaomi's MiMo-V2-Pro is a serious API-only reasoning entrant in the frontier AI space. Surfacing shortly after the release of Xiaomi's open-weight MiMo-V2-Flash, this Pro model achieves a score of 49 on the Artificial Analysis Intelligence Index. It features a massive 1M context window and is priced at $1.00 in / $3.00 out per 1M tokens. Reviewers note its strong token efficiency and lower hallucination rates compared to peers.
+
+---
+
+## Architectural Breakthroughs & Features
+
+While deep architectural details remain proprietary, early evaluations highlight several key strengths:
+
+*   **API-Only Deployment:** Unlike its predecessor (MiMo-V2-Flash), the V2-Pro version is strictly available via API, suggesting a focus on providing managed, high-performance reasoning for enterprise and developer use cases.
+*   **Strong Reasoning Performance:** Achieving an Artificial Analysis score of 49 and a GDPval-AA Elo of 1426, it competes closely with top-tier models like [GLM-5](glm-5.md).
+*   **Massive Context Window:** The 1M token context window allows for processing vast amounts of data - such as entire code repositories or long-form documents - in a single prompt.
+*   **Token Efficiency & Reduced Hallucinations:** Early reports point out favorable token efficiency and a relatively high AA-Omniscience score (+5), driven by significantly reduced hallucination rates.
+
+---
+
+## Real-World Application & Who Should Care
+
+### 🚀 The Performance Monsters (SOTA Seekers)
+**Why you care:** MiMo-V2-Pro introduces another strong competitor in the high-end reasoning space, specifically from a massive hardware company entering the frontier API market.
+**Action:** Test MiMo-V2-Pro against proprietary models for complex reasoning tasks that require digesting massive context windows (up to 1M tokens) with high reliability.
+
+### 💰 The Cost & Latency Optimizers (API Developers)
+**Why you care:** At $1.00 per 1M input tokens and $3.00 per 1M output tokens, it offers a compelling price point for its level of reasoning capability.
+**Action:** Evaluate if MiMo-V2-Pro's reported token efficiency can further reduce overall costs in data-heavy pipelines compared to similarly priced APIs.
+
+### 💻 The Everyday Prompt Engineers
+**Why you care:** The 1M context window is a game-changer for daily workflows involving large files.
+**Action:** Use MiMo-V2-Pro for "needle-in-a-haystack" tasks, such as summarizing long transcripts or debugging large, interconnected code files where maintaining context is critical.
+
+---
+
+## References
+*   [Latent Space: AINews - MiniMax 2.7: GLM-5 at 1/3 cost SOTA Open Model](https://www.latent.space/p/ainews-minimax-27-glm-5-at-13-cost)
+*   [Price Per Token: New AI Model Releases](https://pricepertoken.com/news/model-releases)


### PR DESCRIPTION
- Created `minimax-m2-7.md` and `xiaomi-mimo-v2-pro.md` covering the newly released models.
- Cross-linked M2.7 in `glm-5.md` and MiMo-V2-Pro in `hunter-alpha-mimo.md`.
- Indexed the models in `README.md`.
- Added new files to `check_links.sh`.
- Replaced em-dashes with short hyphens to respect the stylistic constraint.

---
*PR created automatically by Jules for task [3375565933627756982](https://jules.google.com/task/3375565933627756982) started by @tryigit*