### PR TITLE
feat(papers): add Chain-of-Experience and FlashPrefill V2

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ A smart knowledge base about artificial intelligence.
 *   [OpenManus: The Open-Source Framework for General AI Agents](models/openmanus.md) - *An open-source alternative to Manus for creating and customizing advanced agentic workflows without an invite code.*
 
 ## Frontier Research & Papers
+*   [Chain-of-Experience for Continual LLM Improvement](papers/chain-of-experience-for-continual-llm-improvement.md) - *A framework that forms a continual improvement loop beyond zero-shot inference by accumulating experiential traces through iterative interactions with self or environmental feedback.*
+*   [FlashPrefill V2: Block-Sparse Prefill Attention for Long-Context LLM Serving](papers/flashprefill-v2.md) - *Evolves block-sparse prefill attention toward practical long-context serving with mean correction, PackGQA memory access, and native support for continuous batching and FP8.*
 *   [OmniScientist: An Omni-Modal Omni-Discipline AI Scientist](papers/omniscientist.md) - *An end-to-end, omni-modal AI scientist that conducts multidisciplinary research directly from heterogeneous raw evidence via a perception layer and specialized agents.*
 *   [Agent Lightning v1.0: Towards Harnessed Agentic RL](papers/agent-lightning.md) - *A lightweight framework for harnessed agentic RL that addresses challenges in retokenization, sample merging, and backend scheduling by delegating the environment interaction loop to the deploy-time harness.*
 *   [HarnessEval-W: Agentifying the Evaluation of Visual Worlds](papers/harnesseval-w.md) - *An agentified evaluation pipeline that interprets context, decomposes evaluation questions, and spawns specialized sub-agents to provide a verifiable reasoning chain for world model rollouts.*

--- a/concepts/flash-attention.md
+++ b/concepts/flash-attention.md
@@ -53,3 +53,5 @@ While you won't write code for FlashAttention, you benefit from it directly. It 
 See also: [Flux Attention](../papers/flux-attention.md)
 
 See also: [Long Context Pre-Training with Lighthouse Attention](../papers/lighthouse-attention.md)
+
+See also: [FlashPrefill V2: Block-Sparse Prefill Attention for Long-Context LLM Serving](../papers/flashprefill-v2.md)

--- a/concepts/inference-time-compute.md
+++ b/concepts/inference-time-compute.md
@@ -81,3 +81,5 @@ See also: [Self-Guided Test-Time Training for Long-Context LLMs](../papers/self-
 See also: [Boogu-Image-0.1: Boosting Open-Source Unified Multimodal Understanding and Generation](../models/boogu-image-0-1.md)
 
 See also: [Thought-Level Beam Search for Reasoning](../papers/thought-level-beam-search.md)
+
+See also: [Chain-of-Experience for Continual LLM Improvement](../papers/chain-of-experience-for-continual-llm-improvement.md)

--- a/papers/chain-of-experience-for-continual-llm-improvement.md
+++ b/papers/chain-of-experience-for-continual-llm-improvement.md
@@ -1,0 +1,20 @@
+# Chain-of-Experience for Continual LLM Improvement
+
+## TL;DR
+**Chain-of-Experience (CoE)** is a framework that allows large language models (LLMs) to continuously improve themselves beyond zero-shot inference by learning from test-time interactions. Instead of relying solely on the capabilities acquired during pre-training, CoE enables models to accumulate "experiential traces" through iterative interactions with self-generated feedback or environmental signals (like code execution results). This creates a continual improvement loop where models refine their reasoning paths, leading to higher accuracy per token than existing test-time strategies like simple re-sampling or standard self-reflection.
+
+Traditional evaluations often ignore an LLM's capacity to adapt at inference time. CoE bridges this gap by demonstrating that leveraging iterative experience consistently outperforms feedback-free baselines. This applies across diverse domains such as math, coding, and general knowledge. The framework shows that even without external ground-truth labels, models can achieve substantial gains using self-feedback alone, reducing overall API costs while improving performance. Furthermore, CoE reveals a positive correlation between a model's foundational capabilities and its capacity to improve through experience, while remaining robust even if the feedback is weak or spurious.
+
+## Real-World Application & Who Should Care
+
+(Rocket) THE PERFORMANCE MONSTERS (SOTA Seekers):
+For researchers and power users maximizing reasoning capability, CoE represents a significant step up in [Inference-Time Compute: The New Scaling Law (System 2 Thinking)](../concepts/inference-time-compute.md). By structuring test-time compute into an experiential loop, you can achieve higher performance ceilings on complex reasoning and coding benchmarks compared to simple prompt engineering or best-of-N sampling, especially when combining self-feedback with environmental execution signals.
+
+(Money) THE COST & LATENCY OPTIMIZERS (API Developers):
+CoE offers a compelling efficiency argument: it achieves higher accuracy per token than brute-force test-time scaling strategies. The research indicates up to a 19% lower API cost across tasks and models when using CoE, because the model learns to correct its trajectory rather than blindly generating independent samples until one passes. Most gains emerge early in the iteration cycle, meaning you can cap the loop quickly to maintain latency targets while still reaping accuracy benefits.
+
+(Person at Computer) THE EVERYDAY PROMPT ENGINEERS:
+When using powerful models (like GPT-5 or Claude-4.5 Sonnet) via web interfaces, you can manually simulate the CoE loop. Instead of just asking for a solution and accepting it or starting over entirely, prompt the model to review its previous attempt, identify errors (or provide it the error message from your code runner), and generate a revised attempt based explicitly on that "experience." This structured iteration is fundamentally more effective than one-shot prompting for hard tasks.
+
+## References
+* [Chain-of-Experience for Continual LLM Improvement](https://arxiv.org/abs/2608.18027)

--- a/papers/flashprefill-v2.md
+++ b/papers/flashprefill-v2.md
@@ -1,0 +1,25 @@
+# FlashPrefill V2: Block-Sparse Prefill Attention for Long-Context LLM Serving
+
+## TL;DR
+**FlashPrefill V2** evolves the original FlashPrefill from an algorithmic prototype into a practical, production-ready solution for serving Large Language Models (LLMs) with long contexts. The primary bottleneck in long-context modeling is the quadratic computational cost of attention, specifically during the compute-heavy "prefill" phase when the model processes the initial prompt.
+
+FlashPrefill V2 tackles this bottleneck by making block-sparse attention highly efficient and deployable on modern hardware. It introduces three major advancements:
+1.  **Mean Correction:** A mathematical adjustment that suppresses approximation errors, allowing for extreme sparsity levels without unmanageable performance degradation.
+2.  **Hardware-Aligned Redesign:** The sparse attention operator is redesigned with PackGQA memory access, warp specialization, and pingpong pipelining. This fully aligns it with the latest FlashAttention-3/4 implementations and crucially adds support for FP8 inference to meet modern quantization needs.
+3.  **Serving Integration:** It natively supports paged KV caching and continuous batching, making it ready to be used as a backend in standard inference engines like SGLang.
+
+On standard NVIDIA H20 GPUs, FlashPrefill V2 delivers massive speedups: up to 47.26x faster than FlashAttention-2 at 128K context lengths in FP8, and roughly 30.49x faster than even an optimized dense baseline aligned with FA3/4.
+
+## Real-World Application & Who Should Care
+
+(Rocket) THE PERFORMANCE MONSTERS (SOTA Seekers):
+For those pushing the boundaries of extremely long contexts (e.g., 128K+ tokens for document analysis or codebase understanding), FlashPrefill V2 dramatically reduces the time-to-first-token (TTFT). This acceleration is critical for interactive agentic workflows where large context windows must be ingested repeatedly and rapidly.
+
+(Money) THE COST & LATENCY OPTIMIZERS (API Developers):
+This is a direct, substantial win for infrastructure engineers. The prefill phase of long prompts is notoriously expensive and latency-inducing. By integrating FlashPrefill V2 into serving frameworks (like SGLang or vLLM), you can achieve 30x+ speedups during prefill on H20/H100 hardware, especially when utilizing FP8 quantization. The native support for continuous batching and paged KV caches means this optimization fits seamlessly into modern, high-throughput production serving architectures without sacrificing accuracy.
+
+(Person at Computer) THE EVERYDAY PROMPT ENGINEERS:
+While this is a backend infrastructural improvement, its impact on the end user is profound. It means that when you upload massive files-like entire books or large code repositories-to an AI chat interface, the model will "read" and begin responding to that prompt significantly faster, making long-context workflows feel much more interactive and less sluggish.
+
+## References
+* [FlashPrefill V2: Block-Sparse Prefill Attention for Long-Context LLM Serving](https://arxiv.org/abs/2608.19758)


### PR DESCRIPTION
Adds syntheses for Chain-of-Experience (arXiv:2608.18027) and FlashPrefill V2 (arXiv:2608.19758). Updates README and cross-links related concepts.

---
*PR created automatically by Jules for task [2660096568436079851](https://jules.google.com/task/2660096568436079851) started by @tryigit*