### PR TITLE
feat(paper): add The Embedder's Dilemma cost analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ A smart knowledge base about artificial intelligence.
 *   [OpenManus: The Open-Source Framework for General AI Agents](models/openmanus.md) - *An open-source alternative to Manus for creating and customizing advanced agentic workflows without an invite code.*
 
 ## Frontier Research & Papers
+*   [The Embedder's Dilemma: LLMs Are Better, but at What Cost?](papers/embedders-dilemma-llms-vs-embedding-models.md) - *A cost-aware comparison showing that while LLMs excel at reasoning-heavy retrieval, traditional embedding models provide comparable aggregate performance across tasks for significantly lower cost and higher speed.*
 *   [Chain-of-Experience for Continual LLM Improvement](papers/chain-of-experience-for-continual-llm-improvement.md) - *A framework that forms a continual improvement loop beyond zero-shot inference by accumulating experiential traces through iterative interactions with self or environmental feedback.*
 *   [FlashPrefill V2: Block-Sparse Prefill Attention for Long-Context LLM Serving](papers/flashprefill-v2.md) - *Evolves block-sparse prefill attention toward practical long-context serving with mean correction, PackGQA memory access, and native support for continuous batching and FP8.*
 *   [OmniScientist: An Omni-Modal Omni-Discipline AI Scientist](papers/omniscientist.md) - *An end-to-end, omni-modal AI scientist that conducts multidisciplinary research directly from heterogeneous raw evidence via a perception layer and specialized agents.*

--- a/concepts/rotary-position-embedding.md
+++ b/concepts/rotary-position-embedding.md
@@ -55,3 +55,5 @@ This means the model inherently understands "Token B is 3 spots away from Token 
 See also: [Incantation: Natural Language as the Action Interface for Multi-Entity Video World Models](../papers/incantation-natural-language-action.md)
 
 See also: [Positional versus Symbolic Attention Heads](../papers/positional-vs-symbolic-attention.md)
+
+See also: [The Embedder's Dilemma: LLMs Are Better, but at What Cost?](../papers/embedders-dilemma-llms-vs-embedding-models.md)

--- a/papers/embedders-dilemma-llms-vs-embedding-models.md
+++ b/papers/embedders-dilemma-llms-vs-embedding-models.md
@@ -1,0 +1,36 @@
+# The Embedder's Dilemma: LLMs Are Better, but at What Cost?
+
+**TL;DR:** A large-scale, cost-aware comparison reveals that replacing dedicated text-embedding pipelines with Large Language Models (LLMs) yields effectively identical aggregate performance (0.4 point difference). However, reaching that parity is extraordinarily expensive. LLMs cost up to 1,431x more than comparable embedding models and process tokens up to 736x slower. The research suggests a strict division of labor: use embedding models for similarity, classification, and clustering, and reserve expensive LLMs exclusively for reasoning-intensive retrieval tasks.
+
+## The Cost of Reasoning in Embeddings
+
+As LLMs grow more capable, there is a temptation to use them as universal embedding engines. The assumption is that their superior reasoning capabilities will translate into richer, more nuanced semantic spaces. This study tests that assumption across 10 LLMs and 26 embedding models, spanning 118M to 14B parameters on 37 distinct tasks.
+
+The findings present a stark dilemma for system architects:
+
+*   **Parity in the Aggregate:** The best LLM tested (Gemini 3.1 Pro, scoring 77.6) and the best dedicated embedding model (scoring 77.2) are virtually tied in overall performance.
+*   **The Specialization Split:**
+    *   **LLMs** dominate in reasoning-heavy retrieval tasks where understanding complex context and logical relationships is paramount.
+    *   **Embedding Models** hold a clear lead in standard classification tasks.
+    *   **Dead Heat:** For clustering, Semantic Textual Similarity (STS), and pair classification, both paradigms perform equally well.
+*   **The Price Tag:** Utilizing an LLM for embeddings costs up to 1,431x more per benchmark pass (e.g., $154 USD vs. $0.11 USD). Furthermore, open LLMs evaluate tokens 2.5x to 736x slower on identical GPU hardware.
+
+Notably, the study found that *reasoning tokens* account for 28% to 81% of an LLM's inference cost. In many cases, constraining this reasoning budget actually preserves or even improves retrieval quality, indicating that unconstrained LLM "thinking" is often wasteful for pure embedding generation.
+
+## Real-World Application & Who Should Care
+
+### 🚀 THE PERFORMANCE MONSTERS (SOTA Seekers)
+For cutting-edge RAG systems demanding the absolute highest accuracy in complex, multi-hop reasoning or nuanced document retrieval, deploying a top-tier LLM as an embedder (like Gemini 3.1 Pro) is justifiable. You can squeeze out marginal gains in these specific reasoning-intensive scenarios where traditional models falter.
+
+### 💰 THE COST & LATENCY OPTIMIZERS (API Developers)
+This paper is your shield against architectural bloat. Do not succumb to the hype of replacing your embedding pipelines with LLMs. The Pareto frontier firmly supports using dedicated embedding models for the vast majority of tasks (similarity, classification, clustering). The 1,431x cost differential and massive latency hit make LLMs economically unviable for high-throughput semantic search or vector database indexing.
+
+### 💻 THE EVERYDAY PROMPT ENGINEERS
+This research primarily affects the backend architecture of the AI tools you use rather than your day-to-day prompting. However, it highlights an important conceptual boundary: just because an LLM *can* do something (like represent text as vectors) doesn't mean it is the right tool for the job.
+
+## References
+*   [The Embedder's Dilemma: LLMs Are Better, but at What Cost?](https://arxiv.org/abs/2608.12875)
+
+See also: [Rotary Position Embedding (RoPE)](../concepts/rotary-position-embedding.md)
+
+See also: [Your UnEmbedding Matrix is Secretly a Feature Lens for Text Embeddings](embedfilter-unembedding-matrix.md)

--- a/papers/embedfilter-unembedding-matrix.md
+++ b/papers/embedfilter-unembedding-matrix.md
@@ -35,3 +35,5 @@ This specific advancement is foundational and structural to how the model genera
 
 ## Sources
 *   [Your UnEmbedding Matrix is Secretly a Feature Lens for Text Embeddings](https://arxiv.org/abs/2606.07502) (Hugging Face Daily Papers)
+
+See also: [The Embedder's Dilemma: LLMs Are Better, but at What Cost?](embedders-dilemma-llms-vs-embedding-models.md)


### PR DESCRIPTION
Added a new article analyzing "The Embedder's Dilemma" (arxiv 2608.12875). It explains the cost vs. performance trade-offs of using LLMs compared to traditional models for text embeddings, including practical applications for three distinct engineering personas. Cross-linked with related concepts like RoPE and EmbedFilter. Updated README.md accordingly.

---
*PR created automatically by Jules for task [3509027779692767997](https://jules.google.com/task/3509027779692767997) started by @tryigit*