### PR TITLE
feat(paper): add TileMix mixed-precision attention analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ A smart knowledge base about artificial intelligence.
 *   [OpenManus: The Open-Source Framework for General AI Agents](models/openmanus.md) - *An open-source alternative to Manus for creating and customizing advanced agentic workflows without an invite code.*
 
 ## Frontier Research & Papers
+*   [TileMix: Tile-Centric Mixed-Precision Attention for LLM Inference Acceleration](papers/tilemix-mixed-precision-attention.md) - *A tile-centric precision-routing kernel for dense self-attention that dynamically chooses between FP16 and INT8 computation at the score-tile level, improving long-context prefill throughput without sacrificing quality.*
 *   [Let's Scale Step by Step: Compute-Efficient Hyperparameter Transfer for Large-Scale Mixture-of-Experts](papers/moe-compute-efficient-transfer.md) - *A framework for predicting optimal learning rates for massive MoE models by transferring hyperparameter configurations from small proxy models across both width and token budgets.*
 *   [Repo0: Design-Driven Zero-to-All Code Generation](papers/repo0-code-generation.md) - *A continuous structural evolution framework using a Dual-DAG architectural state to guide LLM agents in generating entire software repositories from natural language.*
 *   [Inject, Align, Recover: Staged Post-Training for Retrieval-Free Document Knowledge Internalization](papers/inject-align-recover.md) - *A three-stage post-training framework that converts bounded document collections into parametric knowledge, offering an alternative to inference-time RAG.*

--- a/concepts/flash-attention.md
+++ b/concepts/flash-attention.md
@@ -55,3 +55,5 @@ See also: [Flux Attention](../papers/flux-attention.md)
 See also: [Long Context Pre-Training with Lighthouse Attention](../papers/lighthouse-attention.md)
 
 See also: [FlashPrefill V2: Block-Sparse Prefill Attention for Long-Context LLM Serving](../papers/flashprefill-v2.md)
+
+See also: [TileMix: Tile-Centric Mixed-Precision Attention for LLM Inference Acceleration](../papers/tilemix-mixed-precision-attention.md)

--- a/concepts/quantization.md
+++ b/concepts/quantization.md
@@ -55,3 +55,5 @@ See also: [AlphaQ: Calibration-Free Bit Allocation for Mixture-of-Experts Quanti
 See also: [CineMobile: On-Device Image-to-Video Diffusion for Cinematic Camera Motion Generation](../papers/cinemobile-on-device-image-to-video-diffusion.md)
 
 See also: [KronQ: LLM Quantization via Kronecker-Factored Hessian](../papers/kronq-llm-quantization.md)
+
+See also: [TileMix: Tile-Centric Mixed-Precision Attention for LLM Inference Acceleration](../papers/tilemix-mixed-precision-attention.md)

--- a/papers/tilemix-mixed-precision-attention.md
+++ b/papers/tilemix-mixed-precision-attention.md
@@ -1,0 +1,29 @@
+# TileMix: Tile-Centric Mixed-Precision Attention for LLM Inference Acceleration
+
+## TL;DR
+Long-context prefill in Large Language Models (LLMs) suffers from massive computation and memory bottlenecks because dense self-attention computes quadratic query-key scores. Existing solutions either force the entire attention matrix into uniform low-precision (hurting model quality) or rely on sparse selection of tokens (which can miss important context). **TileMix** introduces a novel kernel that treats numerical precision as a spatial, executable decision. It partitions the attention matrix into hardware-aligned score tiles and dynamically dispatches each tile to either FP16 or INT8 precision. This allows LLMs to retain dense connectivity and long-context quality while reaping the inference speedups and memory reductions of INT8 execution where it is safe to do so.
+
+## Real-World Application & Who Should Care
+
+(Rocket) THE PERFORMANCE MONSTERS (SOTA Seekers):
+For researchers pushing the absolute limits of context windows, TileMix offers a way to maintain the reasoning capability and quality of dense attention in long contexts, recovering the exact performance lost when using naive, uniform INT8 quantization, without introducing the structural complexities of sparse attention.
+
+(Money) THE COST & LATENCY OPTIMIZERS (API Developers):
+This is highly relevant for scaling inference infrastructure. Because TileMix uses a shared online-softmax state and dynamic hardware-aligned precision routing, you get the throughput benefits of mixed precision (FP16 and INT8) during long-context prefill natively on A100s. It drops easily into your existing stack since it supports grouped-query attention, continuous/variable-length batching, and INT8 KV caches—directly driving down your latency per token without needing complex re-training.
+
+(Person at Computer) THE EVERYDAY PROMPT ENGINEERS:
+While you will not interact with TileMix directly via a prompt, this technique enables API providers to process your massive context prompts (like dropping in a 100-page document) much faster. It ensures that when you feed huge walls of text to an LLM, it doesn't arbitrarily ignore critical sentences (which can happen with sparse token selection) or hallucinate due to aggressive quantization.
+
+## How TileMix Works
+Rather than applying a one-size-fits-all [Quantization: Shrinking Models for the Real World](../concepts/quantization.md) method across the entire attention computation, TileMix operates at the "tile" level (a small block of queries and keys that fit neatly into the GPU's memory architecture, similar to the foundational ideas behind [FlashAttention: IO-Aware Exact Attention](../concepts/flash-attention.md)).
+
+1. **Hardware-Aligned Partitioning:** TileMix chops the massive quadratic attention matrix into smaller score tiles.
+2. **Precision Routing Kernel:** It introduces a bitmask-based decision layer. Some token interactions are highly sensitive and require FP16 precision, while others are robust enough to be computed in INT8.
+3. **Unified Updates:** Whether a tile is computed in FP16 or INT8, TileMix routes both streams into a shared online-softmax state. This ensures mathematical correctness and stable gradients/activations without tearing the attention calculation apart.
+4. **No Re-Training Required:** Because it dynamically routes standard dense attention tokens based on metadata compact enough to scale to long contexts, it preserves dense connectivity out of the box and requires zero retraining or finetuning of the base model.
+
+By making precision a localized spatial decision rather than a global model state, TileMix establishes a new frontier where we can precisely balance accuracy and efficiency during the computationally intensive prefill phase.
+
+## References
+* [arXiv:2608.17336 - TileMix: Tile-Centric Mixed-Precision Attention for LLM Inference Acceleration](https://arxiv.org/abs/2608.17336)
+* [GitHub Repository: HanzhiZhang-Ulrica/TileMix](https://github.com/HanzhiZhang-Ulrica/TileMix)


### PR DESCRIPTION
Added analysis of the TileMix paper (arXiv:2608.17336), detailing its tile-centric precision-routing kernel for accelerated LLM inference. Interlinked with Quantization and FlashAttention concepts.

---
*PR created automatically by Jules for task [4025217490077592073](https://jules.google.com/task/4025217490077592073) started by @tryigit*